### PR TITLE
Feature 40 모각코 생성에 작성자 정보 추가

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -28,8 +28,12 @@ public class MogakkoService {
     private final UserRepository userRepository;
     private final MogakkoTagRepository mogakkoTagRepository;
 
-    public MogakkoCreateResponseDto save(MogakkoCreateRequestDto requestDto) { // TODO: 생성한 사용자 관련 로직 추가
+    public MogakkoCreateResponseDto save(MogakkoCreateRequestDto requestDto) {
         Mogakko mogakko = createMogakkoBy(requestDto);
+
+        User creator = userRepository.findById(requestDto.creatorId())
+            .orElseThrow(RuntimeException::new);// TODO: 유저 에러 반환
+        mogakko.updateCreator(creator);
 
         Mogakko savedMogakko = mogakkoRepository.save(mogakko);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -7,7 +7,6 @@ import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
-import org.prgms.locomocoserver.mogakkos.dto.request.SelectedTagsDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
@@ -58,10 +57,9 @@ public class MogakkoService {
     }
 
     private Mogakko createMogakkoBy(MogakkoCreateRequestDto requestDto) {
-        List<SelectedTagsDto> selectedTagsDtos = requestDto.tags();
         Mogakko mogakko = requestDto.toMogakkoWithoutTags();
 
-        List<Long> tagIds = selectedTagsDtos.stream().flatMap(dto -> dto.tagIds().stream()).toList();
+        List<Long> tagIds = requestDto.tags();
         List<Tag> tags = tagRepository.findAllById(tagIds);
 
         tags.forEach(tag -> {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
@@ -13,7 +13,7 @@ public record MogakkoCreateRequestDto(@Schema(description = "작성자 id") Long
                                       @Schema(description = "모각코 모집 데드라인 시간") LocalDateTime deadline,
                                       @Schema(description = "최대 참여자 수") Integer maxParticipants,
                                       @Schema(description = "모각코 글 내용") String content,
-                                      @Schema(description = "선택된 태그 id 모음") List<SelectedTagsDto> tags) {
+                                      @Schema(description = "선택된 태그 id 모음") List<Long> tags) {
 
     public Mogakko toMogakkoWithoutTags() {
         return Mogakko.builder()

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
@@ -5,7 +5,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 
-public record MogakkoCreateRequestDto(@Schema(description = "모각코 글 제목") String title,
+public record MogakkoCreateRequestDto(@Schema(description = "작성자 id") Long creatorId,
+                                      @Schema(description = "모각코 글 제목") String title,
                                       @Schema(description = "모각코 장소") String location,
                                       @Schema(description = "모각코 시작 시간") LocalDateTime startTime,
                                       @Schema(description = "모각코 종료 시간") LocalDateTime endTime,

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/SelectedTagsDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/SelectedTagsDto.java
@@ -1,9 +1,0 @@
-package org.prgms.locomocoserver.mogakkos.dto.request;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.List;
-
-public record SelectedTagsDto(@Schema(description = "카테고리 id") Long categoryId,
-                              @Schema(description = "태그 id 리스트") List<Long> tagIds) {
-
-}

--- a/src/test/java/org/prgms/locomocoserver/categories/application/CategoryServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/categories/application/CategoryServiceTest.java
@@ -3,6 +3,7 @@ package org.prgms.locomocoserver.categories.application;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,12 @@ class CategoryServiceTest {
         coding.addTag(backend);
 
         tagRepository.saveAll(List.of(js, python, codingTest, backend));
+    }
+
+    @AfterEach
+    void tearDown() {
+        tagRepository.deleteAll();
+        categoryRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
@@ -26,7 +26,7 @@ class UserRepositoryTest {
     private MogakkoRepository mogakkoRepository;
 
     @Test
-    @DisplayName("특정 모각코에 참여중인 목록들을 전부 가져올 수 있다.")
+    @DisplayName("특정 모각코에 참여중인 인원 목록을 전부 가져올 수 있다.")
     void success_find_all_participants_by_mogakko() {
         // given
         LocalDateTime startTime = LocalDateTime.now();
@@ -42,7 +42,7 @@ class UserRepositoryTest {
 
         Mogakko mogakko = Mogakko.builder().title("title").content("content").startTime(
                 startTime).endTime(startTime.plusHours(2)).deadline(startTime.plusHours(1))
-            .likeCount(0).location("어떤 곳").views(0).build();
+            .likeCount(0).location("어떤 곳").views(0).creator(user1).build();
 
         Participant participant1 = participantRepository.save(
             Participant.builder().user(user1).build());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #40 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 이전에는 모각코 생성 시에 작성자가 누군지 정해줄 수 없었으나 이제 작성자(유저) id를 클라이언트에서 보내주면 이것을 이용해 매핑합니다.
- JSON 형식이 조금 바뀌었습니다. FE에서 카테고리-태그를 최초 앱 구동시에 전부 가지고 있다고 가정하에 생성 시 태그 id 값만 전달해주면 해당하는 태그들을 매핑합니다. 이전에는 카테고리 id도 넘겨주어야 했으나 이를 삭제했습니다. `MogakkoCreateRequestDto` 변경 사항에서 이를 확인할 수 있습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
간단한 작업입니다. 이해 안되는 코드 혹은 비효율적인 코드가 있는지 봐주시면 감사하겠습니다~!