### PR TITLE
Feature 42 모각코 업데이트 및 삭제 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/global/common/BaseEntity.java
+++ b/src/main/java/org/prgms/locomocoserver/global/common/BaseEntity.java
@@ -30,7 +30,7 @@ public abstract class BaseEntity {
         return this.deletedAt != null;
     }
 
-    protected void delete() {
+    public void delete() {
         if (isDeleted()) throw new IllegalArgumentException("이미 삭제된 엔티티 입니다.");
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -79,9 +79,7 @@ public class MogakkoService {
     public void delete(Long id) {
         Mogakko foundMogakko = getByIdNotDeleted(id);
 
-        foundMogakko.remove();
-
-        mogakkoRepository.save(foundMogakko);
+        foundMogakko.delete();
     }
 
     public Mogakko getByIdNotDeleted(Long id) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -1,23 +1,28 @@
 package org.prgms.locomocoserver.mogakkos.application;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.SelectedTagsDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoParticipantDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.prgms.locomocoserver.user.dto.response.UserBriefInfoDto;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -53,11 +58,66 @@ public class MogakkoService {
         return new MogakkoDetailResponseDto(creatorInfoDto, mogakkoParticipantDtos, mogakkoInfoDto);
     }
 
+    @Transactional
+    public MogakkoUpdateResponseDto update(MogakkoUpdateRequestDto requestDto, Long id) {
+        Mogakko foundMogakko = getByIdNotDeleted(id);
+
+        validateCreator(requestDto, foundMogakko);
+
+        foundMogakko.updateInfo(requestDto.title(), requestDto.content(), requestDto.startTime(),
+            requestDto.endTime(), requestDto.deadline(), requestDto.maxParticipants(),
+            requestDto.location());
+        updateMogakkoTags(foundMogakko, requestDto.tags());
+
+        return new MogakkoUpdateResponseDto(foundMogakko.getId());
+    }
+
+    public Mogakko getByIdNotDeleted(Long id) {
+        return mogakkoRepository.findByIdAndDeletedAtIsNull(id)
+            .orElseThrow(RuntimeException::new); // TODO: 모각코 에러 반환
+    }
+
+    private static void validateCreator(MogakkoUpdateRequestDto requestDto, Mogakko foundMogakko) {
+        if (!foundMogakko.isSameCreatorId(requestDto.updateUserId())) {
+            throw new RuntimeException(); // TODO: 유저 예외 반환
+        }
+    }
+
+    private void updateMogakkoTags(Mogakko updateMogakko, List<Long> updateTagIds) {
+        final int DELETE_TAG = 0;
+        final int MAINTAIN_TAG = 1;
+        final int INSERT_TAG = 2;
+        final Map<Tag, Integer> tagMap = new HashMap<>();
+
+        List<MogakkoTag> existingMogakkoTags = mogakkoTagRepository.findAllByMogakko(updateMogakko);
+        List<Tag> updateTags = tagRepository.findAllById(updateTagIds);
+
+        existingMogakkoTags.forEach(mogakkoTag -> tagMap.put(mogakkoTag.getTag(), DELETE_TAG));
+
+        updateTags.forEach(tag -> {
+            if (tagMap.get(tag) == null) {
+                tagMap.put(tag, INSERT_TAG);
+            }
+            else {
+                tagMap.put(tag, MAINTAIN_TAG);
+            }
+        });
+
+        tagMap.forEach((tag, status) -> {
+            switch (status) {
+                case DELETE_TAG -> mogakkoTagRepository.deleteByTag(tag);
+                case INSERT_TAG -> mogakkoTagRepository.save(
+                    MogakkoTag.builder().mogakko(updateMogakko).tag(tag).build());
+            }
+        });
+    }
+
     private Mogakko createMogakkoBy(MogakkoCreateRequestDto requestDto) {
         List<SelectedTagsDto> selectedTagsDtos = requestDto.tags();
         Mogakko mogakko = requestDto.toMogakkoWithoutTags();
 
-        List<Long> tagIds = selectedTagsDtos.stream().flatMap(dto -> dto.tagIds().stream()).toList();
+        List<Long> tagIds = selectedTagsDtos.stream().flatMap(dto -> dto.tagIds().stream())
+            .toList();
         List<Tag> tags = tagRepository.findAllById(tagIds);
 
         tags.forEach(tag -> {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -81,7 +81,7 @@ public class MogakkoService {
     }
 
     private static void validateCreator(MogakkoUpdateRequestDto requestDto, Mogakko foundMogakko) {
-        if (!foundMogakko.isSameCreatorId(requestDto.updateUserId())) {
+        if (!foundMogakko.isSameCreatorId(requestDto.creatorId())) {
             throw new RuntimeException(); // TODO: 유저 예외 반환
         }
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -35,8 +35,6 @@ public class MogakkoService {
     public MogakkoCreateResponseDto save(MogakkoCreateRequestDto requestDto) {
         Mogakko mogakko = createMogakkoBy(requestDto);
 
-
-        
         User creator = userRepository.findById(requestDto.creatorId())
             .orElseThrow(RuntimeException::new);// TODO: 유저 에러 반환
         mogakko.updateCreator(creator);
@@ -47,7 +45,7 @@ public class MogakkoService {
     }
 
     public MogakkoDetailResponseDto findDetail(Long id) {
-        Mogakko foundMogakko = mogakkoRepository.findByIdAndDeletedAtIsNull(id).orElseThrow(RuntimeException::new); // TODO: 모각코 에러 반환
+        Mogakko foundMogakko = getByIdNotDeleted(id);
         User creator = userRepository.findByIdAndDeletedAtIsNull(foundMogakko.getCreator().getId())
             .orElseGet(() -> User.builder().nickname("(알 수 없음)").build());
         List<User> participants = userRepository.findAllParticipantsByMogakko(foundMogakko);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -75,6 +75,15 @@ public class MogakkoService {
         return new MogakkoUpdateResponseDto(foundMogakko.getId());
     }
 
+    @Transactional
+    public void delete(Long id) {
+        Mogakko foundMogakko = getByIdNotDeleted(id);
+
+        foundMogakko.remove();
+
+        mogakkoRepository.save(foundMogakko);
+    }
+
     public Mogakko getByIdNotDeleted(Long id) {
         return mogakkoRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(RuntimeException::new); // TODO: 모각코 에러 반환
@@ -82,7 +91,7 @@ public class MogakkoService {
 
     private static void validateCreator(MogakkoUpdateRequestDto requestDto, Mogakko foundMogakko) {
         if (!foundMogakko.isSameCreatorId(requestDto.creatorId())) {
-            throw new RuntimeException(); // TODO: 유저 예외 반환
+            throw new RuntimeException(); // TODO: 모각코 예외 반환
         }
     }
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -131,4 +131,8 @@ public class Mogakko extends BaseEntity {
         this.maxParticipants = maxParticipants;
         this.location = location;
     }
+
+    public void remove() {
+        delete();
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -116,4 +116,19 @@ public class Mogakko extends BaseEntity {
     public void updateCreator(User creator) {
         this.creator = creator;
     }
+
+    public boolean isSameCreatorId(Long creatorId) {
+        return this.creator.getId().equals(creatorId);
+    }
+
+    public void updateInfo(String title, String content, LocalDateTime startTime, LocalDateTime endTime,
+        LocalDateTime deadline, int maxParticipants, String location) {
+        this.title = title;
+        this.content = content;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.deadline = deadline;
+        this.maxParticipants = maxParticipants;
+        this.location = location;
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -131,8 +131,4 @@ public class Mogakko extends BaseEntity {
         this.maxParticipants = maxParticipants;
         this.location = location;
     }
-
-    public void remove() {
-        delete();
-    }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
@@ -2,6 +2,7 @@ package org.prgms.locomocoserver.mogakkos.domain.mogakkotags;
 
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.tags.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,4 +10,5 @@ public interface MogakkoTagRepository extends JpaRepository<MogakkoTag, Long> {
 
     @Query("SELECT mt FROM MogakkoTag mt WHERE mt.mogakko = :mogakko")
     List<MogakkoTag> findAllByMogakko(Mogakko mogakko);
+    void deleteByTag(Tag tag);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
@@ -1,0 +1,18 @@
+package org.prgms.locomocoserver.mogakkos.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+
+public record MogakkoUpdateRequestDto(@Schema(description = "수정하려는 유저 id") Long updateUserId,
+                                      @Schema(description = "모각코 글 제목") String title,
+                                      @Schema(description = "모각코 장소") String location,
+                                      @Schema(description = "모각코 시작 시간") LocalDateTime startTime,
+                                      @Schema(description = "모각코 종료 시간") LocalDateTime endTime,
+                                      @Schema(description = "모각코 모집 데드라인 시간") LocalDateTime deadline,
+                                      @Schema(description = "최대 참여자 수") int maxParticipants,
+                                      @Schema(description = "모각코 글 내용") String content,
+                                      @Schema(description = "선택된 태그 id 모음") List<Long> tags) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
@@ -3,7 +3,6 @@ package org.prgms.locomocoserver.mogakkos.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 
 public record MogakkoUpdateRequestDto(@Schema(description = "수정하려는 유저 id") Long updateUserId,
                                       @Schema(description = "모각코 글 제목") String title,

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoUpdateRequestDto.java
@@ -4,14 +4,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record MogakkoUpdateRequestDto(@Schema(description = "수정하려는 유저 id") Long updateUserId,
-                                      @Schema(description = "모각코 글 제목") String title,
-                                      @Schema(description = "모각코 장소") String location,
+public record MogakkoUpdateRequestDto(@Schema(description = "수정하려는 유저 id", example = "1") Long creatorId,
+                                      @Schema(description = "모각코 글 제목", example = "이게 무슨 일이야 이렇게 좋은 날에") String title,
+                                      @Schema(description = "모각코 장소", example = "서울 서초구 강남대로 327") String location,
                                       @Schema(description = "모각코 시작 시간") LocalDateTime startTime,
                                       @Schema(description = "모각코 종료 시간") LocalDateTime endTime,
                                       @Schema(description = "모각코 모집 데드라인 시간") LocalDateTime deadline,
-                                      @Schema(description = "최대 참여자 수") int maxParticipants,
-                                      @Schema(description = "모각코 글 내용") String content,
+                                      @Schema(description = "최대 참여자 수", example = "2") int maxParticipants,
+                                      @Schema(description = "모각코 글 내용", example = "난... ㄱ ㅏ끔... 눈물을 흘린 ㄷ ㅏ ...") String content,
                                       @Schema(description = "선택된 태그 id 모음") List<Long> tags) {
 
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoCreateResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoCreateResponseDto.java
@@ -1,7 +1,7 @@
 package org.prgms.locomocoserver.mogakkos.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record MogakkoCreateResponseDto(@JsonProperty("mogakko_id") Long id) {
+public record MogakkoCreateResponseDto(@Schema(description = "생성된 모각코 id") Long id) {
 
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoUpdateResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoUpdateResponseDto.java
@@ -1,5 +1,7 @@
 package org.prgms.locomocoserver.mogakkos.dto.response;
 
-public record MogakkoUpdateResponseDto(Long mogakkoId) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MogakkoUpdateResponseDto(@Schema(description = "수정된 모각코 id") Long id) {
 
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoUpdateResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoUpdateResponseDto.java
@@ -1,0 +1,5 @@
+package org.prgms.locomocoserver.mogakkos.dto.response;
+
+public record MogakkoUpdateResponseDto(Long mogakkoId) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -8,11 +8,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,6 +48,18 @@ public class MogakkoController {
     public ResponseEntity<MogakkoDetailResponseDto> findDetail(
         @Parameter(description = "조회할 모각코 id") @PathVariable Long id) {
         MogakkoDetailResponseDto responseDto = mogakkoService.findDetail(id);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/mogakko/map/{id}")
+    @Operation(summary = "모각코 수정", description = "수정할 정보를 넘겨주면 해당 내용을 기반으로 DB에서 값을 수정하고 응답 값으로 수정된 모각코 id를 넘겨줍니다.")
+    @ApiResponses(
+        @ApiResponse(responseCode = "200", description = "모각코 수정 성공")
+    )
+    public ResponseEntity<MogakkoUpdateResponseDto> update(
+        @RequestBody MogakkoUpdateRequestDto requestDto, @PathVariable Long id) {
+        MogakkoUpdateResponseDto responseDto = mogakkoService.update(requestDto, id);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -4,15 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.prgms.locomocoserver.categories.domain.Category;
 import org.prgms.locomocoserver.categories.domain.CategoryRepository;
 import org.prgms.locomocoserver.categories.domain.CategoryType;
@@ -23,8 +27,10 @@ import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository
 import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
 import org.prgms.locomocoserver.user.domain.User;
@@ -36,8 +42,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 @TestInstance(Lifecycle.PER_CLASS)
+@TestMethodOrder(OrderAnnotation.class)
 class MogakkoServiceTest {
 
+    private final List<Long> tagIds = new ArrayList<>();
     @Autowired
     private MogakkoService mogakkoService;
     @Autowired
@@ -52,13 +60,15 @@ class MogakkoServiceTest {
     private UserRepository userRepository;
     @Autowired
     private ParticipantRepository participantRepository;
-
-    private final List<Long> tagIds = new ArrayList<>();
+    private User setUpUser1, setUpUser2;
+    private Mogakko testMogakko;
 
     @BeforeAll
     void setUp() {
-        Category langs = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 언어").build();
-        Category coding = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 유형").build();
+        Category langs = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 언어")
+            .build();
+        Category coding = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 유형")
+            .build();
 
         categoryRepository.saveAll(List.of(langs, coding));
 
@@ -73,6 +83,23 @@ class MogakkoServiceTest {
         coding.addTag(backend);
 
         tagRepository.saveAll(List.of(js, python, codingTest, backend));
+
+        setUpUser1 = userRepository.save(
+            User.builder().nickname("생성자").email("cho@gmail.com").job(Job.JOB_SEEKER).birth(
+                LocalDate.EPOCH).gender(Gender.MALE).temperature(36.5).provider("github").build());
+        setUpUser2 = userRepository.save(
+            User.builder().nickname("참여자1").email("part@gmail.com").job(Job.DEVELOPER).birth(
+                LocalDate.EPOCH).gender(Gender.FEMALE).temperature(42.1).provider("kakao").build());
+        testMogakko = Mogakko.builder().title("title").content("제곧내").views(20).likeCount(10)
+            .location("어딘가").startTime(LocalDateTime.now())
+            .endTime(LocalDateTime.now().plusHours(2)).deadline(LocalDateTime.now().plusHours(1))
+            .creator(setUpUser1).build();
+
+        mogakkoRepository.save(testMogakko);
+        tagRepository.findAll().forEach(tag -> mogakkoTagRepository.save(MogakkoTag.builder()
+            .tag(tag).mogakko(testMogakko).build()));
+        participantRepository.save(
+            Participant.builder().user(setUpUser2).mogakko(testMogakko).build());
 
         tagIds.addAll(List.of(js.getId(), python.getId(), codingTest.getId(), backend.getId()));
     }
@@ -111,7 +138,8 @@ class MogakkoServiceTest {
         MogakkoCreateResponseDto responseDto = mogakkoService.save(mogakkoCreateRequestDto);
 
         // then
-        Optional<Mogakko> mogakkoOptional = mogakkoRepository.findByIdAndDeletedAtIsNull(responseDto.id());
+        Optional<Mogakko> mogakkoOptional = mogakkoRepository.findByIdAndDeletedAtIsNull(
+            responseDto.id());
         assertThat(mogakkoOptional.isPresent()).isTrue();
 
         Mogakko createdMogakko = mogakkoOptional.get();
@@ -125,26 +153,10 @@ class MogakkoServiceTest {
 
     @Test
     @DisplayName("id 값으로 특정 모각코 디테일 정보를 가져올 수 있다")
+    @Order(1)
     void success_find_mogakko_info_in_detail() {
-        // given
-        User savedCreator = userRepository.save(
-            User.builder().nickname("생성자").email("cho@gmail.com").job(Job.JOB_SEEKER).birth(
-                LocalDate.EPOCH).gender(Gender.MALE).temperature(36.5).provider("github").build());
-        User participant = userRepository.save(
-            User.builder().nickname("참여자1").email("part@gmail.com").job(Job.DEVELOPER).birth(
-                LocalDate.EPOCH).gender(Gender.FEMALE).temperature(42.1).provider("kakao").build());
-        Mogakko mogakko = Mogakko.builder().title("title").content("제곧내").views(20).likeCount(10)
-            .location("어딘가").startTime(LocalDateTime.now())
-            .endTime(LocalDateTime.now().plusHours(2)).deadline(LocalDateTime.now().plusHours(1))
-            .creator(savedCreator).build();
-
-        mogakkoRepository.save(mogakko);
-        tagRepository.findAll().forEach(tag -> mogakkoTagRepository.save(MogakkoTag.builder()
-            .tag(tag).mogakko(mogakko).build()));
-        participantRepository.save(Participant.builder().user(participant).mogakko(mogakko).build());
-
         // when
-        MogakkoDetailResponseDto responseDto = mogakkoService.findDetail(mogakko.getId());
+        MogakkoDetailResponseDto responseDto = mogakkoService.findDetail(testMogakko.getId());
 
         // then
         assertThat(responseDto.creatorInfo()).isNotNull();
@@ -152,5 +164,42 @@ class MogakkoServiceTest {
         assertThat(responseDto.participants()).hasSize(1);
         assertThat(responseDto.MogakkoInfo().title()).isEqualTo("title");
         assertThat(responseDto.MogakkoInfo().tagIds()).hasSize(4);
+    }
+
+    @Test
+    @DisplayName("모각코 정보를 업데이트 할 수 있다")
+    @Order(2)
+    void success_update_mogakko_info_and_tags() {
+        // given
+        String updateTitle = "바뀐 제목";
+        String updateLocation = "바뀐 장소";
+        String updateContent = "바뀐 내용";
+
+        MogakkoUpdateRequestDto requestDto = new MogakkoUpdateRequestDto(
+            setUpUser1.getId(), updateTitle, updateLocation,
+            testMogakko.getStartTime(), testMogakko.getStartTime().plusHours(5),
+            testMogakko.getDeadline(),
+            testMogakko.getMaxParticipants(), updateContent, List.of(tagIds.get(2)));
+
+        // when
+        MogakkoUpdateResponseDto responseDto = mogakkoService.update(requestDto, testMogakko.getId());
+
+        // then
+        assertThat(responseDto.mogakkoId()).isEqualTo(testMogakko.getId());
+
+        Optional<Mogakko> mogakkoOptional = mogakkoRepository.findById(testMogakko.getId());
+        assertThat(mogakkoOptional.isPresent()).isTrue();
+
+        Mogakko updatedMogakko = mogakkoOptional.get();
+        List<MogakkoTag> updatedMogakkoTags = mogakkoTagRepository.findAllByMogakko(updatedMogakko);
+
+        assertThat(updatedMogakko.getTitle()).isEqualTo(updateTitle);
+        assertThat(updatedMogakko.getContent()).isEqualTo(updateContent);
+        assertThat(updatedMogakko.getLocation()).isEqualTo(updateLocation);
+        assertThat(updatedMogakko.getEndTime().truncatedTo(ChronoUnit.MILLIS))
+            .isEqualTo(testMogakko.getStartTime().plusHours(5).truncatedTo(ChronoUnit.MILLIS));
+
+        assertThat(updatedMogakkoTags).hasSize(1);
+        assertThat(updatedMogakkoTags.get(0).getTag().getId()).isEqualTo(tagIds.get(2));
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -185,7 +185,7 @@ class MogakkoServiceTest {
         MogakkoUpdateResponseDto responseDto = mogakkoService.update(requestDto, testMogakko.getId());
 
         // then
-        assertThat(responseDto.mogakkoId()).isEqualTo(testMogakko.getId());
+        assertThat(responseDto.id()).isEqualTo(testMogakko.getId());
 
         Optional<Mogakko> mogakkoOptional = mogakkoRepository.findById(testMogakko.getId());
         assertThat(mogakkoOptional.isPresent()).isTrue();


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #42 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
더티 체킹을 기본적으로 활용합니다. 각 알고리즘을 아래 자세히 적어두었습니다. 

### 수정
  - 태그를 제외한 다른 컬럼 값들은 바로 수정합니다.
  - 태그는 `updateMogakkoTags()` 메서드에서 업데이트 합니다. 다음 과정을 거칩니다.
    1. 업데이트 할 모각코 id를 이용해 모각코-태그를 전부 가져옵니다.
    2. 가져온 모각코-태그에서 태그들을 `Map`에 넣어둡니다. Key는 태그, Value는 상태입니다.
        - 상태는 DELETE, MAINTAIN, INSERT 3가지가 있으며 DELETE면 삭제할 모각코-태그, MAINTAIN은 유지할 모각코-태그, INSERT는 추가할 모각코-태그입니다.
    3. 넣어둘 때 최초 Value는 DELETE입니다.
    4. 이제 업데이트할 태그 id들을 `TagRepository`에서 전부 가져옵니다.
    5. 가져온 태그들을 돌면서 `Map`에 존재하는지 확인하며 다음을 수행합니다. 
        - 존재하면 Value를 MAINTAIN으로 바꿉니다.
        - 존재하지 않으면 Map에 해당 태그를 추가합니다. Value는 INSERT 입니다.
    6. 이제 태그들을 돌면서 DELETE면 모각코-태그에서 삭제, INSERT면 모각코-태그에 추가합니다.
### 삭제
  - deletedAt 시간만 조절하는 soft delete를 사용

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
수정 알고리즘의 효율성을 중점으로 봐주시면 감사하겠습니다! 
위처럼 알고리즘을 짠 이유는 쿼리를 최대한 덜 날리면서 시간 효율을 최대화하기 위해 짰습니다.