### PR TITLE
Feature 46 모각코 리스트 필터링 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -74,8 +74,9 @@ public class MogakkoService {
         return new MogakkoDetailResponseDto(creatorInfoDto, mogakkoParticipantDtos, mogakkoInfoDto);
     }
 
-    public List<MogakkoSimpleInfoResponseDto> findAll() {
-        List<Mogakko> mogakkos = mogakkoRepository.findAll();
+    @Transactional(readOnly = true)
+    public List<MogakkoSimpleInfoResponseDto> findAll(Long cursor) {
+        List<Mogakko> mogakkos = mogakkoRepository.findAll(cursor);
 
         return mogakkos.stream().map(mogakko -> {
             Location location = locationRepository.findByMogakko(mogakko)
@@ -85,12 +86,9 @@ public class MogakkoService {
         }).toList();
     }
 
+    @Transactional(readOnly = true)
     public List<MogakkoSimpleInfoResponseDto> findAllByTagIds(List<Long> tagIds, Long cursor) {
-        if (tagIds == null) {
-            return findAll();
-        }
-
-        List<Long> filteredMogakkoIds = mogakkoRepository.findAllIdsByTagIds(tagIds, tagIds.size(), cursor);
+        List<Long> filteredMogakkoIds = mogakkoTagRepository.findAllIdsByTagIds(tagIds, tagIds.size(), cursor);
         List<Mogakko> filteredMogakkos = mogakkoRepository.findAllById(filteredMogakkoIds);
 
         return filteredMogakkos.stream().map(mogakko -> {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
@@ -16,6 +17,7 @@ import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoParticipantDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
@@ -28,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MogakkoService {
 
     private final MogakkoRepository mogakkoRepository;
@@ -66,9 +69,35 @@ public class MogakkoService {
             .toList();
         List<Long> tagIds = mogakkoTags.stream().map(mogakkoTag -> mogakkoTag.getTag().getId())
             .toList();
-        MogakkoInfoDto mogakkoInfoDto = MogakkoInfoDto.create(foundMogakko, LocationInfoDto.create(foundLocation) , tagIds);
+        MogakkoInfoDto mogakkoInfoDto = MogakkoInfoDto.create(foundMogakko, LocationInfoDto.create(foundLocation), tagIds);
 
         return new MogakkoDetailResponseDto(creatorInfoDto, mogakkoParticipantDtos, mogakkoInfoDto);
+    }
+
+    public List<MogakkoSimpleInfoResponseDto> findAll() {
+        List<Mogakko> mogakkos = mogakkoRepository.findAll();
+
+        return mogakkos.stream().map(mogakko -> {
+            Location location = locationRepository.findByMogakko(mogakko)
+                .orElseThrow(RuntimeException::new);// TODO: 장소 예외 반환
+
+            return MogakkoSimpleInfoResponseDto.create(mogakko, location);
+        }).toList();
+    }
+
+    public List<MogakkoSimpleInfoResponseDto> findAllByTagIds(List<Long> tagIds, Long cursor) {
+        if (tagIds == null) {
+            return findAll();
+        }
+
+        List<Long> filteredMogakkoIds = mogakkoRepository.findAllIdsByTagIds(tagIds, tagIds.size(), cursor);
+        List<Mogakko> filteredMogakkos = mogakkoRepository.findAllById(filteredMogakkoIds);
+
+        return filteredMogakkos.stream().map(mogakko -> {
+            Location location = locationRepository.findByMogakko(mogakko)
+                .orElseThrow(RuntimeException::new);
+            return MogakkoSimpleInfoResponseDto.create(mogakko, location);
+        }).toList();
     }
 
     @Transactional

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -1,8 +1,12 @@
 package org.prgms.locomocoserver.mogakkos.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
+    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON l.mogakko_id = m.id WHERE m.id > :cursor LIMIT 20", nativeQuery = true)
+    List<Mogakko> findAll(Long cursor);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
@@ -10,5 +10,7 @@ public interface MogakkoTagRepository extends JpaRepository<MogakkoTag, Long> {
 
     @Query("SELECT mt FROM MogakkoTag mt WHERE mt.mogakko = :mogakko")
     List<MogakkoTag> findAllByMogakko(Mogakko mogakko);
+    @Query(value = "SELECT mt.mogakko_id FROM mogakko_tags mt WHERE (mt.mogakko_id > :cursor AND mt.tag_id IN :tagIds) GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize LIMIT 20", nativeQuery = true)
+    List<Long> findAllIdsByTagIds(Iterable<Long> tagIds, int tagSize, Long cursor);
     void deleteByTag(Tag tag);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoSimpleInfoResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MogakkoSimpleInfoResponseDto.java
@@ -2,14 +2,28 @@ package org.prgms.locomocoserver.mogakkos.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 
-public record MogakkoSimpleInfoResponseDto(@Schema(description = "제목") String title,
-                                           @Schema(description = "조회 수") int views,
+public record MogakkoSimpleInfoResponseDto(@Schema(description = "모각코 id") Long id,
+                                           @Schema(description = "제목") String title,
+                                           @Schema(description = "조회 수") long views,
                                            @Schema(description = "좋아요(찜) 수") int likeCount,
                                            @Schema(description = "최대 참여자 수") int maxParticipants,
                                            @Schema(description = "현재 참여자 수") int curParticipants,
                                            @Schema(description = "장소 정보") LocationInfoDto location,
                                            @Schema(description = "태그 id 목록") List<Long> tags) {
 
+    public static MogakkoSimpleInfoResponseDto create(Mogakko mogakko, Location location) {
+        return new MogakkoSimpleInfoResponseDto(mogakko.getId(),
+            mogakko.getTitle(),
+            mogakko.getViews(),
+            mogakko.getLikeCount(),
+            mogakko.getMaxParticipants(),
+            mogakko.getParticipants().size(),
+            LocationInfoDto.create(location),
+            mogakko.getMogakkoTags().stream().map(mogakkoTag -> mogakkoTag.getTag().getId())
+                .toList());
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -43,8 +43,16 @@ public class MogakkoController {
         @ApiResponse(responseCode = "200", description = "모각코 목록 반환 성공")
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
-        @Parameter(description = "필터링 태그 id 목록") @RequestParam List<Long> tags) {
-        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByTagIds(tags);
+        @Parameter(description = "필터링 커서") @RequestParam(required = false, defaultValue = "0") Long cursor,
+        @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
+        List<MogakkoSimpleInfoResponseDto> responseDtos;
+
+        if (tags == null) {
+            responseDtos = mogakkoService.findAll(cursor);
+        }
+        else {
+            responseDtos = mogakkoService.findAllByTagIds(tags, cursor);
+        }
 
         Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -43,21 +43,12 @@ public class MogakkoController {
         @ApiResponse(responseCode = "200", description = "모각코 목록 반환 성공")
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
-        @Parameter(description = "필터링 태그 id 목록") @RequestParam List<Long> tags) { // TODO: 실 구현 필요
-        ArrayList<MogakkoSimpleInfoResponseDto> responseDtos = new ArrayList<>();
+        @Parameter(description = "필터링 태그 id 목록") @RequestParam List<Long> tags) {
+        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByTagIds(tags);
 
-        List<LocationInfoDto> dummyLocationInfoDtos = List.of(
-            new LocationInfoDto("서울 구로구 구로동 1124-49", 37.48499109823538, 126.90030884433865, "구로동"),
-            new LocationInfoDto("서울 구로구 디지털로32나길 17-28", 37.48483748703877, 126.89978894154596,
-                "구로동"));
+        Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);
 
-        IntStream.range(0, 10).forEach(i -> responseDtos.add(
-            new MogakkoSimpleInfoResponseDto("제모옥" + i, i * 10, i * 3, i % 8 + 2, 1,
-                dummyLocationInfoDtos.get(i % 2), List.of((long) i, (long) i + 1, (long) i + 2))));
-
-        Results<MogakkoSimpleInfoResponseDto> responseDto = new Results<>(responseDtos);
-
-        return ResponseEntity.ok(responseDto);
+        return ResponseEntity.ok(results);
     }
 
     @PutMapping("/mogakko/map")

--- a/src/test/java/org/prgms/locomocoserver/categories/application/CategoryServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/categories/application/CategoryServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgms.locomocoserver.categories.domain.Category;
+import org.prgms.locomocoserver.categories.domain.CategoryInputType;
 import org.prgms.locomocoserver.categories.domain.CategoryRepository;
 import org.prgms.locomocoserver.categories.domain.CategoryType;
 import org.prgms.locomocoserver.categories.dto.response.CategoriesWithTagsDto;
@@ -29,8 +30,10 @@ class CategoryServiceTest {
 
     @BeforeEach
     void setUp() {
-        Category langs = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 언어").build();
-        Category coding = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 유형").build();
+        Category langs = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 언어")
+            .categoryInputType(CategoryInputType.CHECKBOX).build();
+        Category coding = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 유형")
+            .categoryInputType(CategoryInputType.COMBOBOX).build();
 
         categoryRepository.saveAll(List.of(langs, coding));
 

--- a/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
@@ -42,7 +42,7 @@ class UserRepositoryTest {
 
         Mogakko mogakko = Mogakko.builder().title("title").content("content").startTime(
                 startTime).endTime(startTime.plusHours(2)).deadline(startTime.plusHours(1))
-            .likeCount(0).location("어떤 곳").views(0).creator(user1).build();
+            .likeCount(0).views(0).creator(user1).build();
 
         Participant participant1 = participantRepository.save(
             Participant.builder().user(user1).build());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #46 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
무한 스크롤을 사용한다고 가정하고 커서를 이용해 데이터를 끌고 올 수 있도록 했습니다.
필터링은 일단 커서(마지막 모각코 데이터의 id)와 태그들을 받고, 태그들을 이용해 모각코-태그 테이블에서 모든 태그가 있는 모각코 id만 가져옵니다.
그리고 그 모각코 id를 이용해 모각코를 조회하고 각각에 대해 DTO 생성 후 반환합니다.

N + 1 문제가 발생하지만 추후 레코드들이 많이 추가된다면 조인으로 인한 시간 손실도 만만치 않다고 판단해 일단 그대로 두었습니다. (고민해야 할 부분...)

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
쿼리가 핵심이라 쿼리 위주로 봐주시면 감사하겠습니다! 버그가 있을 것 같은 코드들도 잡아주시면 좋습니다.