### PR TITLE
Feature 63 city 검색 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -87,8 +87,8 @@ public class MogakkoService {
     }
 
     @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAllByTagIds(List<Long> tagIds, Long cursor) {
-        List<Long> filteredMogakkoIds = mogakkoTagRepository.findAllIdsByTagIds(tagIds, tagIds.size(), cursor);
+    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, Long cursor, String city) {
+        List<Long> filteredMogakkoIds = mogakkoTagRepository.findAllIdsByfilter(tagIds, tagIds.size(), cursor, city);
         List<Mogakko> filteredMogakkos = mogakkoRepository.findAllById(filteredMogakkoIds);
 
         return filteredMogakkos.stream().map(mogakko -> {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -75,8 +75,8 @@ public class MogakkoService {
     }
 
     @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAll(Long cursor) {
-        List<Mogakko> mogakkos = mogakkoRepository.findAll(cursor);
+    public List<MogakkoSimpleInfoResponseDto> findAllByCity(Long cursor, String city) {
+        List<Mogakko> mogakkos = mogakkoRepository.findAll(cursor, city);
 
         return mogakkos.stream().map(mogakko -> {
             Location location = locationRepository.findByMogakko(mogakko)

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
-    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON (m.id > :cursor AND l.mogakko_id = m.id AND l.city LIKE :city%) LIMIT 20", nativeQuery = true)
+    @Query(value = "SELECT m.* FROM mogakko m "
+        + "JOIN locations l ON (m.id > :cursor AND m.deleted_at IS NULL AND l.mogakko_id = m.id AND l.city LIKE :city%) "
+        + "LIMIT 20", nativeQuery = true)
     List<Mogakko> findAll(Long cursor, String city);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
-    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON l.mogakko_id = m.id WHERE m.id > :cursor LIMIT 20", nativeQuery = true)
-    List<Mogakko> findAll(Long cursor);
+    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON l.mogakko_id = m.id AND l.city LIKE :city% WHERE m.id > :cursor LIMIT 20", nativeQuery = true)
+    List<Mogakko> findAll(Long cursor, String city);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
-    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON l.mogakko_id = m.id AND l.city LIKE :city% WHERE m.id > :cursor LIMIT 20", nativeQuery = true)
+    @Query(value = "SELECT m.* FROM mogakko m JOIN locations l ON (m.id > :cursor AND l.mogakko_id = m.id AND l.city LIKE :city%) LIMIT 20", nativeQuery = true)
     List<Mogakko> findAll(Long cursor, String city);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
@@ -10,7 +10,14 @@ public interface MogakkoTagRepository extends JpaRepository<MogakkoTag, Long> {
 
     @Query("SELECT mt FROM MogakkoTag mt WHERE mt.mogakko = :mogakko")
     List<MogakkoTag> findAllByMogakko(Mogakko mogakko);
-    @Query(value = "SELECT mt.mogakko_id FROM mogakko_tags mt WHERE (mt.mogakko_id > :cursor AND mt.tag_id IN :tagIds) GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize LIMIT 20", nativeQuery = true)
-    List<Long> findAllIdsByTagIds(Iterable<Long> tagIds, int tagSize, Long cursor);
+    @Query(value = "SELECT mt.mogakko_id "
+        + "FROM mogakko_tags mt "
+        + "JOIN mogakko m ON m.id > :cursor AND m.deleted_at IS NULL AND m.id = mt.mogakko_id "
+        + "JOIN locations l ON l.mogakko_id = m.id AND l.city LIKE :city% "
+        + "WHERE mt.tag_id IN :tagIds "
+        + "GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize "
+        + "ORDER BY mt.mogakko_id "
+        + "LIMIT 20", nativeQuery = true)
+    List<Long> findAllIdsByfilter(Iterable<Long> tagIds, int tagSize, Long cursor, String city);
     void deleteByTagAndMogakko(Tag tag, Mogakko mogakko);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -50,7 +50,7 @@ public class MogakkoController {
             responseDtos = mogakkoService.findAllByCity(cursor, city);
         }
         else {
-            responseDtos = mogakkoService.findAllByTagIds(tags, cursor);
+            responseDtos = mogakkoService.findAllByFilter(tags, cursor, city);
         }
 
         Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -5,12 +5,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.global.common.dto.Results;
-import org.prgms.locomocoserver.location.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
@@ -44,11 +41,13 @@ public class MogakkoController {
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
         @Parameter(description = "필터링 커서") @RequestParam(required = false, defaultValue = "0") Long cursor,
+        @Parameter(description = "동/읍/면") @RequestParam(required = false, defaultValue = "") String city,
         @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
         List<MogakkoSimpleInfoResponseDto> responseDtos;
+        city = city.strip();
 
         if (tags == null) {
-            responseDtos = mogakkoService.findAll(cursor);
+            responseDtos = mogakkoService.findAllByCity(cursor, city);
         }
         else {
             responseDtos = mogakkoService.findAllByTagIds(tags, cursor);


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #63 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
기존 필터링 메서드에 주소(동/읍/면)를 추가하여 필터링이 가능하도록 했습니다. [주소, 태그] 둘 다 이용하여 필터링 할 수도 있고 둘 중 하나만 이용해서 필터링 할 수도 있으며 전부 사용하지 않고 리스트를 나열할 수도 있습니다.

JOIN 절을 추가해 주소 필터링이 가능하도록 했으며, 모각코-태그 필터링 시에도 모각코와 장소를 JOIN으로 연결했습니다. 이전에 deleted_at IS NULL 부분 빼먹어서 추가도 했습니다.

그리고 장소(locations)의 city에 인덱스 걸면 더 빨라질 것 같아서 인덱스 붙여보려 합니다. (더 빨라지는지는 확실하지 않음)

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
쿼리 부분 역시 확인 부탁드립니다~ 그리고 버그가 있을 것 같은 부분 있는지 확인도 부탁드립니다.