### PR TITLE
Feature 82 통합검색 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -85,7 +85,7 @@ public class MogakkoService {
             new SearchRepositoryDto(mogakkoRepository, locationRepository, mogakkoTagRepository));
         List<Mogakko> searchedMogakkos;
 
-        if (tagIds.isEmpty()) {
+        if (tagIds == null || tagIds.isEmpty()) {
             searchedMogakkos = searchPolicy.search(cursor, searchVal);
         } else {
             searchedMogakkos = searchPolicy.search(cursor, searchVal, tagIds);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -82,7 +82,7 @@ public class MogakkoService {
     public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, Long cursor,
         String searchVal, SearchType searchType) {
         SearchPolicy searchPolicy = searchType.getSearchPolicy(
-            new SearchRepositoryDto(mogakkoRepository, locationRepository, mogakkoTagRepository));
+            new SearchRepositoryDto(mogakkoRepository, mogakkoTagRepository));
         List<Mogakko> searchedMogakkos;
 
         if (tagIds == null || tagIds.isEmpty()) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -8,10 +8,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
+import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
@@ -65,33 +67,31 @@ public class MogakkoService {
             .orElseThrow(RuntimeException::new); // TODO: 장소 예외 반환
 
         UserBriefInfoDto creatorInfoDto = UserBriefInfoDto.of(creator);
-        List<MogakkoParticipantDto> mogakkoParticipantDtos = participants.stream().map(MogakkoParticipantDto::create)
+        List<MogakkoParticipantDto> mogakkoParticipantDtos = participants.stream()
+            .map(MogakkoParticipantDto::create)
             .toList();
         List<Long> tagIds = mogakkoTags.stream().map(mogakkoTag -> mogakkoTag.getTag().getId())
             .toList();
-        MogakkoInfoDto mogakkoInfoDto = MogakkoInfoDto.create(foundMogakko, LocationInfoDto.create(foundLocation), tagIds);
+        MogakkoInfoDto mogakkoInfoDto = MogakkoInfoDto.create(foundMogakko,
+            LocationInfoDto.create(foundLocation), tagIds);
 
         return new MogakkoDetailResponseDto(creatorInfoDto, mogakkoParticipantDtos, mogakkoInfoDto);
     }
 
     @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAllByCity(Long cursor, String city) {
-        List<Mogakko> mogakkos = mogakkoRepository.findAll(cursor, city);
+    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, Long cursor,
+        String searchVal, SearchType searchType) {
+        SearchPolicy searchPolicy = searchType.getSearchPolicy(
+            new SearchRepositoryDto(mogakkoRepository, locationRepository, mogakkoTagRepository));
+        List<Mogakko> searchedMogakkos;
 
-        return mogakkos.stream().map(mogakko -> {
-            Location location = locationRepository.findByMogakko(mogakko)
-                .orElseThrow(RuntimeException::new);// TODO: 장소 예외 반환
+        if (tagIds.isEmpty()) {
+            searchedMogakkos = searchPolicy.search(cursor, searchVal);
+        } else {
+            searchedMogakkos = searchPolicy.search(cursor, searchVal, tagIds);
+        }
 
-            return MogakkoSimpleInfoResponseDto.create(mogakko, location);
-        }).toList();
-    }
-
-    @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, Long cursor, String city) {
-        List<Long> filteredMogakkoIds = mogakkoTagRepository.findAllIdsByfilter(tagIds, tagIds.size(), cursor, city);
-        List<Mogakko> filteredMogakkos = mogakkoRepository.findAllById(filteredMogakkoIds);
-
-        return filteredMogakkos.stream().map(mogakko -> {
+        return searchedMogakkos.stream().map(mogakko -> {
             Location location = locationRepository.findByMogakko(mogakko)
                 .orElseThrow(RuntimeException::new);
             return MogakkoSimpleInfoResponseDto.create(mogakko, location);
@@ -144,8 +144,7 @@ public class MogakkoService {
         updateTags.forEach(tag -> {
             if (tagMap.get(tag) == null) {
                 tagMap.put(tag, INSERT_TAG);
-            }
-            else {
+            } else {
                 tagMap.put(tag, MAINTAIN_TAG);
             }
         });
@@ -161,7 +160,6 @@ public class MogakkoService {
 
     private Mogakko createMogakkoBy(MogakkoCreateRequestDto requestDto) {
         Mogakko mogakko = requestDto.toDefaultMogakko();
-
 
         List<Long> tagIds = requestDto.tags();
         List<Tag> tags = tagRepository.findAllById(tagIds);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
@@ -9,7 +9,7 @@ import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
 public enum SearchType {
     TOTAL(dto -> new TotalSearchPolicy(dto.mogakkoRepository(), dto.locationRepository(),
         dto.mogakkoTagRepository())),
-    LOCATION(dto -> new LocationSearchPolicy(dto.mogakkoRepository(), dto.locationRepository(),
+    LOCATION(dto -> new LocationSearchPolicy(dto.mogakkoRepository(),
         dto.mogakkoTagRepository()));
 
     private final Function<SearchRepositoryDto, SearchPolicy> searchPolicy;

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
@@ -7,8 +7,7 @@ import org.prgms.locomocoserver.mogakkos.application.searchpolicy.TotalSearchPol
 import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
 
 public enum SearchType {
-    TOTAL(dto -> new TotalSearchPolicy(dto.mogakkoRepository(), dto.locationRepository(),
-        dto.mogakkoTagRepository())),
+    TOTAL(dto -> new TotalSearchPolicy(dto.mogakkoRepository())),
     LOCATION(dto -> new LocationSearchPolicy(dto.mogakkoRepository(),
         dto.mogakkoTagRepository()));
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
@@ -1,0 +1,24 @@
+package org.prgms.locomocoserver.mogakkos.application;
+
+import java.util.function.Function;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.LocationSearchPolicy;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.TotalSearchPolicy;
+import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
+
+public enum SearchType {
+    TOTAL(dto -> new TotalSearchPolicy(dto.mogakkoRepository(), dto.locationRepository(),
+        dto.mogakkoTagRepository())),
+    LOCATION(dto -> new LocationSearchPolicy(dto.mogakkoRepository(), dto.locationRepository(),
+        dto.mogakkoTagRepository()));
+
+    private final Function<SearchRepositoryDto, SearchPolicy> searchPolicy;
+
+    SearchType(Function<SearchRepositoryDto, SearchPolicy> searchPolicy) {
+        this.searchPolicy = searchPolicy;
+    }
+
+    public SearchPolicy getSearchPolicy(SearchRepositoryDto dto) {
+        return searchPolicy.apply(dto);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -1,7 +1,6 @@
 package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
 
 import java.util.List;
-import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
@@ -9,13 +8,10 @@ import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository
 public class LocationSearchPolicy implements SearchPolicy {
 
     private final MogakkoRepository mogakkoRepository;
-    private final LocationRepository locationRepository;
     private final MogakkoTagRepository mogakkoTagRepository;
 
-    public LocationSearchPolicy(MogakkoRepository mogakkoRepository,
-        LocationRepository locationRepository, MogakkoTagRepository mogakkoTagRepository) {
+    public LocationSearchPolicy(MogakkoRepository mogakkoRepository, MogakkoTagRepository mogakkoTagRepository) {
         this.mogakkoRepository = mogakkoRepository;
-        this.locationRepository = locationRepository;
         this.mogakkoTagRepository = mogakkoTagRepository;
     }
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -1,0 +1,33 @@
+package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
+
+import java.util.List;
+import org.prgms.locomocoserver.location.domain.LocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
+
+public class LocationSearchPolicy implements SearchPolicy {
+
+    private final MogakkoRepository mogakkoRepository;
+    private final LocationRepository locationRepository;
+    private final MogakkoTagRepository mogakkoTagRepository;
+
+    public LocationSearchPolicy(MogakkoRepository mogakkoRepository,
+        LocationRepository locationRepository, MogakkoTagRepository mogakkoTagRepository) {
+        this.mogakkoRepository = mogakkoRepository;
+        this.locationRepository = locationRepository;
+        this.mogakkoTagRepository = mogakkoTagRepository;
+    }
+
+    @Override
+    public List<Mogakko> search(Long cursor, String searchVal) {
+        return mogakkoRepository.findAllByCity(cursor, searchVal);
+    }
+
+    @Override
+    public List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds) {
+        List<Long> filteredMogakkoIds = mogakkoTagRepository.findAllIdsByCity(tagIds, tagIds.size(), cursor, searchVal);
+
+        return mogakkoRepository.findAllById(filteredMogakkoIds);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
@@ -1,0 +1,9 @@
+package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
+
+import java.util.List;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+
+public interface SearchPolicy {
+    List<Mogakko> search(Long cursor, String searchVal);
+    List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds);
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
@@ -1,0 +1,31 @@
+package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
+
+import java.util.List;
+import org.prgms.locomocoserver.location.domain.LocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
+
+public class TotalSearchPolicy implements SearchPolicy {
+
+    private final MogakkoRepository mogakkoRepository;
+    private final LocationRepository locationRepository;
+    private final MogakkoTagRepository mogakkoTagRepository;
+
+    public TotalSearchPolicy(MogakkoRepository mogakkoRepository,
+        LocationRepository locationRepository, MogakkoTagRepository mogakkoTagRepository) {
+        this.mogakkoRepository = mogakkoRepository;
+        this.locationRepository = locationRepository;
+        this.mogakkoTagRepository = mogakkoTagRepository;
+    }
+
+    @Override
+    public List<Mogakko> search(Long cursor, String searchVal) {
+        return mogakkoRepository.findAllByFilter(cursor, searchVal);
+    }
+
+    @Override
+    public List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds) {
+        return mogakkoRepository.findAllByFilter(cursor, searchVal, tagIds, tagIds.size());
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
@@ -1,22 +1,15 @@
 package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
 
 import java.util.List;
-import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
-import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 
 public class TotalSearchPolicy implements SearchPolicy {
 
     private final MogakkoRepository mogakkoRepository;
-    private final LocationRepository locationRepository;
-    private final MogakkoTagRepository mogakkoTagRepository;
 
-    public TotalSearchPolicy(MogakkoRepository mogakkoRepository,
-        LocationRepository locationRepository, MogakkoTagRepository mogakkoTagRepository) {
+    public TotalSearchPolicy(MogakkoRepository mogakkoRepository) {
         this.mogakkoRepository = mogakkoRepository;
-        this.locationRepository = locationRepository;
-        this.mogakkoTagRepository = mogakkoTagRepository;
     }
 
     @Override

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -15,17 +15,17 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "JOIN locations l ON (m.id > :cursor AND m.deleted_at IS NULL AND l.mogakko_id = m.id AND l.city LIKE :city%) "
         + "LIMIT 20", nativeQuery = true)
     List<Mogakko> findAllByCity(Long cursor, String city);
-    @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
-        + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
-        + "JOIN locations l "
-        + "JOIN mogakko_tags mt ON mt.tag_id IN :tagIds "
+    @Query(value = "SELECT m.* FROM mogakko m "
+        + "INNER JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
+        + "INNER JOIN locations l ON l.mogakko_id = m.id "
+        + "INNER JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
         + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
         + "GROUP BY m.id HAVING count(m.id) = :tagSize "
         + "LIMIT 20", nativeQuery = true)
     List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize); // TODO: 테스트 필요
     @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
-        + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
-        + "JOIN locations l "
+        + "INNER JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
+        + "INNER JOIN locations l ON l.mogakko_id = m.id "
         + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
         + "LIMIT 20", nativeQuery = true)
     List<Mogakko> findAllByFilter(Long cursor, String searchVal); // TODO: 테스트 필요

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -14,7 +14,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query(value = "SELECT m.* FROM mogakko m "
         + "JOIN locations l ON (m.id > :cursor AND m.deleted_at IS NULL AND l.mogakko_id = m.id AND l.city LIKE :city%) "
         + "LIMIT 20", nativeQuery = true)
-    List<Mogakko> findAll(Long cursor, String city);
+    List<Mogakko> findAllByCity(Long cursor, String city);
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime >= :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
     List<Mogakko> findOngoingMogakkosByUser(@Param("user") User user, @Param("now") LocalDateTime now);
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime < :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -19,16 +19,16 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
         + "JOIN locations l "
         + "JOIN mogakko_tags mt ON mt.tag_id IN :tagIds "
-        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %searchVal%) "
+        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
         + "GROUP BY m.id HAVING count(m.id) = :tagSize "
         + "LIMIT 20", nativeQuery = true)
-    List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize);
+    List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize); // TODO: 테스트 필요
     @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
         + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
         + "JOIN locations l "
-        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %searchVal%) "
+        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
         + "LIMIT 20", nativeQuery = true)
-    List<Mogakko> findAllByFilter(Long cursor, String searchVal);
+    List<Mogakko> findAllByFilter(Long cursor, String searchVal); // TODO: 테스트 필요
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime >= :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
     List<Mogakko> findOngoingMogakkosByUser(@Param("user") User user, @Param("now") LocalDateTime now);
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime < :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -15,6 +15,20 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "JOIN locations l ON (m.id > :cursor AND m.deleted_at IS NULL AND l.mogakko_id = m.id AND l.city LIKE :city%) "
         + "LIMIT 20", nativeQuery = true)
     List<Mogakko> findAllByCity(Long cursor, String city);
+    @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
+        + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
+        + "JOIN locations l "
+        + "JOIN mogakko_tags mt ON mt.tag_id IN :tagIds "
+        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %searchVal%) "
+        + "GROUP BY m.id HAVING count(m.id) = :tagSize "
+        + "LIMIT 20", nativeQuery = true)
+    List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize);
+    @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
+        + "JOIN users u ON m.id > :cursor AND m.deleted_at IS NULL AND m.creator_id = u.id "
+        + "JOIN locations l "
+        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %searchVal%) "
+        + "LIMIT 20", nativeQuery = true)
+    List<Mogakko> findAllByFilter(Long cursor, String searchVal);
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime >= :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
     List<Mogakko> findOngoingMogakkosByUser(@Param("user") User user, @Param("now") LocalDateTime now);
     @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime < :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/mogakkotags/MogakkoTagRepository.java
@@ -18,6 +18,6 @@ public interface MogakkoTagRepository extends JpaRepository<MogakkoTag, Long> {
         + "GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize "
         + "ORDER BY mt.mogakko_id "
         + "LIMIT 20", nativeQuery = true)
-    List<Long> findAllIdsByfilter(Iterable<Long> tagIds, int tagSize, Long cursor, String city);
+    List<Long> findAllIdsByCity(Iterable<Long> tagIds, int tagSize, Long cursor, String city);
     void deleteByTagAndMogakko(Tag tag, Mogakko mogakko);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/SearchRepositoryDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/SearchRepositoryDto.java
@@ -1,0 +1,11 @@
+package org.prgms.locomocoserver.mogakkos.dto;
+
+import org.prgms.locomocoserver.location.domain.LocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
+
+public record SearchRepositoryDto (MogakkoRepository mogakkoRepository,
+                                   LocationRepository locationRepository,
+                                   MogakkoTagRepository mogakkoTagRepository
+                                   ) {
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/SearchRepositoryDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/SearchRepositoryDto.java
@@ -1,11 +1,9 @@
 package org.prgms.locomocoserver.mogakkos.dto;
 
-import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 
 public record SearchRepositoryDto (MogakkoRepository mogakkoRepository,
-                                   LocationRepository locationRepository,
                                    MogakkoTagRepository mogakkoTagRepository
                                    ) {
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.global.common.dto.Results;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
+import org.prgms.locomocoserver.mogakkos.application.SearchType;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
@@ -41,17 +42,13 @@ public class MogakkoController {
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
         @Parameter(description = "필터링 커서") @RequestParam(required = false, defaultValue = "0") Long cursor,
-        @Parameter(description = "동/읍/면") @RequestParam(required = false, defaultValue = "") String city,
+        @Parameter(description = "검색 값") @RequestParam(name = "search", required = false, defaultValue = "") String searchVal,
+        @Parameter(description = "검색 타입") @RequestParam SearchType searchType,
         @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
-        List<MogakkoSimpleInfoResponseDto> responseDtos;
-        city = city.strip();
+        searchVal = searchVal.strip();
 
-        if (tags == null) {
-            responseDtos = mogakkoService.findAllByCity(cursor, city);
-        }
-        else {
-            responseDtos = mogakkoService.findAllByFilter(tags, cursor, city);
-        }
+        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags,
+            cursor, searchVal, searchType);
 
         Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #82 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
전체 필터링 검색 구현을 완료했습니다.
DB 한방 쿼리로 이를 가져옵니다. 테스트 코드는 추후 작성하여 테스트해봐야 할 것 같습니다.

TOTAL, LOCATION으로 나누어서 검색을 할 수 있고, TOTAL은 전체 통합 검색, LOCATION은 locations 테이블 내 city 값을 바탕으로 검색합니다. 통합 검색은 작성자 닉네임, 모각코 제목, 모각코 내용, 모각코와 연관된 locations의 city를 전부 뒤지며 태그 필터링이 있으면 그것도 수행합니다.

TOTAL, LOCATION은 따로 `SearchPolicy`로 인터페이스화하였고, 합성으로 구현하였습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
코드 구조 확인해 주시고 쿼리 부분도 봐주시면 감사하겠습니다~!