### PR TITLE
Feature 66 문의 읽기, 삭제 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -46,11 +46,11 @@ public class InquiryService {
     }
 
     @Transactional
-    public void delete(Long id, InquiryDeleteRequestDto requestDto) {
+    public void delete(Long id, Long userId) {
         Inquiry inquiry = inquiryRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(RuntimeException::new); // TODO: 문의 예외 반환
 
-        validateUser(requestDto.userId(), inquiry);
+        validateUser(userId, inquiry);
 
         inquiry.delete();
     }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -1,11 +1,12 @@
 package org.prgms.locomocoserver.inquiries.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.inquiries.domain.Inquiry;
 import org.prgms.locomocoserver.inquiries.domain.InquiryRepository;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryCreateRequestDto;
-import org.prgms.locomocoserver.inquiries.dto.request.InquiryDeleteRequestDto;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryUpdateRequestDto;
+import org.prgms.locomocoserver.inquiries.dto.response.InquiryResponseDto;
 import org.prgms.locomocoserver.inquiries.dto.response.InquiryUpdateResponseDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
@@ -43,6 +44,23 @@ public class InquiryService {
         Inquiry updatedInquiry = inquiryRepository.save(foundInquiry);
 
         return InquiryUpdateResponseDto.create(updatedInquiry);
+    }
+
+    public List<InquiryResponseDto> findAll(Long cursor, Long mogakkoId, Long userId) {
+        List<Inquiry> foundInquries;
+
+        if (mogakkoId == null && userId == null) { // querydsl 도입 시 동적 쿼리로 리팩터링
+            foundInquries = inquiryRepository.findAll(cursor);
+        } else if (mogakkoId == null) {
+            foundInquries = inquiryRepository.findAllByUser(cursor, userId);
+        } else if (userId == null) {
+            foundInquries = inquiryRepository.findAllByMogakko(cursor, mogakkoId);
+        } else {
+            foundInquries = inquiryRepository.findAllByMogakkoAndUser(cursor, mogakkoId, userId);
+        }
+
+        return foundInquries.stream().map(
+            inquiry -> InquiryResponseDto.create(inquiry, inquiry.getUser())).toList();
     }
 
     @Transactional

--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.inquiries.domain.Inquiry;
 import org.prgms.locomocoserver.inquiries.domain.InquiryRepository;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryCreateRequestDto;
+import org.prgms.locomocoserver.inquiries.dto.request.InquiryDeleteRequestDto;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryUpdateRequestDto;
 import org.prgms.locomocoserver.inquiries.dto.response.InquiryUpdateResponseDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
@@ -11,6 +12,7 @@ import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +37,7 @@ public class InquiryService {
         Inquiry foundInquiry = inquiryRepository.findByIdAndDeletedAtIsNull(id)
             .orElseThrow(RuntimeException::new);// TODO: 문의 예외 반환
 
-        validateUser(requestDto, foundInquiry);
+        validateUser(requestDto.userId(), foundInquiry);
 
         foundInquiry.updateInfo(requestDto.content());
         Inquiry updatedInquiry = inquiryRepository.save(foundInquiry);
@@ -43,8 +45,18 @@ public class InquiryService {
         return InquiryUpdateResponseDto.create(updatedInquiry);
     }
 
-    private static void validateUser(InquiryUpdateRequestDto requestDto, Inquiry foundInquiry) {
-        boolean isSameUser = foundInquiry.getUser().getId().equals(requestDto.userId());
+    @Transactional
+    public void delete(Long id, InquiryDeleteRequestDto requestDto) {
+        Inquiry inquiry = inquiryRepository.findByIdAndDeletedAtIsNull(id)
+            .orElseThrow(RuntimeException::new); // TODO: 문의 예외 반환
+
+        validateUser(requestDto.userId(), inquiry);
+
+        inquiry.delete();
+    }
+
+    private static void validateUser(Long inquiryUserId, Inquiry foundInquiry) {
+        boolean isSameUser = foundInquiry.getUser().getId().equals(inquiryUserId);
 
         if (!isSameUser) {
             throw new RuntimeException(); // TODO: 유저 예외 반환

--- a/src/main/java/org/prgms/locomocoserver/inquiries/domain/InquiryRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/domain/InquiryRepository.java
@@ -1,8 +1,30 @@
 package org.prgms.locomocoserver.inquiries.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     Optional<Inquiry> findByIdAndDeletedAtIsNull(Long id);
+    @Query(value = "SELECT i.* FROM inquiries i WHERE id < :cursor "
+        + "ORDER BY i.created_at DESC "
+        + "LIMIT 20", nativeQuery = true)
+    List<Inquiry> findAll(Long cursor);
+    @Query(value = "SELECT i.* FROM inquiries i "
+        + "INNER JOIN users u ON i.id < :cursor AND u.id = :userId AND i.user_id = u.id "
+        + "ORDER BY i.created_at DESC "
+        + "LIMIT 20", nativeQuery = true)
+    List<Inquiry> findAllByUser(Long cursor, Long userId);
+    @Query(value = "SELECT i.* FROM inquiries i "
+        + "INNER JOIN mogakko m ON i.id < :cursor AND m.id = :mogakkoId AND i.mogakko_id = m.id "
+        + "ORDER BY i.created_at DESC "
+        + "LIMIT 20", nativeQuery = true)
+    List<Inquiry> findAllByMogakko(Long cursor, Long mogakkoId);
+    @Query(value = "SELECT i.* FROM inquiries i "
+        + "INNER JOIN mogakko m ON i.id < :cursor AND m.id = :mogakkoId AND i.mogakko_id = m.id "
+        + "INNER JOIN users u ON u.id = :userId AND i.user_id = u.id "
+        + "ORDER BY i.created_at DESC "
+        + "LIMIT 20", nativeQuery = true)
+    List<Inquiry> findAllByMogakkoAndUser(Long cursor, Long mogakkoId, Long userId);
 }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/dto/response/InquiryResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/dto/response/InquiryResponseDto.java
@@ -3,13 +3,26 @@ package org.prgms.locomocoserver.inquiries.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.prgms.locomocoserver.inquiries.domain.Inquiry;
+import org.prgms.locomocoserver.user.domain.User;
 
-public record InquiryResponseDto(@Schema(description = "작성자 id") Long userId,
-                                 @Schema(description = "프로필 사진 저장 위치") String profilePicture,
+public record InquiryResponseDto(@Schema(description = "문의 id") Long inquiryId,
+                                 @Schema(description = "작성자 id") Long userId,
+                                 @Schema(description = "모각코 id") Long mogakkoId,
+                                 @Schema(description = "프로필 사진 저장 위치") String profileImage,
                                  @Schema(description = "작성자 닉네임") String nickname,
                                  @Schema(description = "생성 시간") LocalDateTime createdAt,
                                  @Schema(description = "수정 시간") LocalDateTime updatedAt,
-                                 @Schema(description = "작성 내용") String content,
-                                 @Schema(description = "대댓글 id 목록") List<Long> replies) {
+                                 @Schema(description = "작성 내용") String content) {
+    public static InquiryResponseDto create(Inquiry inquiry, User user) {
+        return new InquiryResponseDto(inquiry.getId(),
+            user.getId(),
+            inquiry.getMogakko().getId(),
+            user.getProfileImage(), // TODO: 추후 S3 연동 후에 로직 변경이 있을 수 있음
+            user.getNickname(),
+            inquiry.getCreatedAt(),
+            inquiry.getUpdatedAt(),
+            inquiry.getContent());
+    }
 
 }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/presentation/InquiryController.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/presentation/InquiryController.java
@@ -90,14 +90,15 @@ public class InquiryController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @Operation(summary = "문의 삭제", description = "작성자 id, 문의 id에 따라 문의를 삭제합니다. 작성자 id는 검증용으로 이용합니다.")
+    @Operation(summary = "문의 삭제", description = "유저 id, 문의 id에 따라 문의를 삭제합니다. 유저 id는 문의 작성자인지 검증하기 위해 이용합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "문의 삭제 성공"),
     })
     @DeleteMapping("/inquiries/{inquiryId}")
     public ResponseEntity<Void> delete(
-        @Parameter(description = "문의 id") @PathVariable(name = "inquiryId") Long id,
-        @Parameter(description = "삭제 정보") @RequestBody InquiryDeleteRequestDto requestDto) { // TODO: 실 구현 필요
+        @Parameter(description = "문의 id") @PathVariable Long inquiryId,
+        @Parameter(description = "유저 id") @RequestParam Long userId) {
+        inquiryService.delete(inquiryId, userId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/presentation/InquiryController.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/presentation/InquiryController.java
@@ -6,17 +6,12 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.global.common.dto.Results;
 import org.prgms.locomocoserver.inquiries.application.InquiryService;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryCreateRequestDto;
-import org.prgms.locomocoserver.inquiries.dto.request.InquiryDeleteRequestDto;
 import org.prgms.locomocoserver.inquiries.dto.request.InquiryUpdateRequestDto;
 import org.prgms.locomocoserver.inquiries.dto.response.InquiryResponseDto;
 import org.prgms.locomocoserver.inquiries.dto.response.InquiryUpdateResponseDto;
@@ -43,24 +38,21 @@ public class InquiryController {
 
     @Operation(summary = "문의 전체 조회", description = "모각코 id, 작성자 id에 해당하는 문의들을 전부 가져옵니다. 각 파라미터는 필수 인자가 아니며, 모든 파라미터를 넘겨주지 않으면 전체 문의가 조회됩니다.")
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "문의 단일 조회 성공"),
+        @ApiResponse(responseCode = "200", description = "문의 전체 조회 성공"),
     })
     @Parameters({
+        @Parameter(name = "cursor", description = "인덱스 커서. 마지막으로 조회한 문의 id. default Value는 사실 9223372036854775807여야 합니다. 스웨거 UI 오류임."),
         @Parameter(name = "mogakkoId", description = "연관된 모각코 id"),
         @Parameter(name = "userId", description = "연관된 작성자 id")
     })
     @GetMapping("/inquiries")
     public ResponseEntity<Results<InquiryResponseDto>> findAll(
+        @RequestParam(defaultValue = "9223372036854775807") Long cursor,
         @RequestParam(required = false) Long mogakkoId,
-        @RequestParam(required = false) Long userId) { // TODO: 실 구현 필요
-        ArrayList<InquiryResponseDto> responseDtos = new ArrayList<>();
+        @RequestParam(required = false) Long userId) {
+        log.info("cursor: {}", cursor);
 
-        IntStream.range(0, 10).forEach(i -> responseDtos.add(
-            new InquiryResponseDto((long) i + 1, "어딘가", "닉넴" + i, LocalDateTime.now().truncatedTo(
-                ChronoUnit.NANOS), LocalDateTime.now().truncatedTo(ChronoUnit.NANOS), "내용",
-                List.of((long) i + 1, (long) i + 2))));
-
-        log.info("mogakkoId = {}, userId = {}", mogakkoId, userId);
+        List<InquiryResponseDto> responseDtos = inquiryService.findAll(cursor, mogakkoId, userId);
 
         return ResponseEntity.status(HttpStatus.OK).body(new Results<>(responseDtos));
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #66 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
문의 읽기와 삭제를 구현했습니다~ 삭제는 간단하게 작성자가 맞으면 실제 삭제를 진행합니다.

문의 읽기는 userId, mogakkoId 에 따라 20개씩 보여줍니다. 이 두 파라미터는 생략이 가능합니다. 이로써 마이페이지에서 문의 조회할 때도 해당 API 호출은 유용할 것으로 기대합니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
동적 쿼리를 짤 수가 없어서 쿼리를 죄다 만들었습니다. 이상한 부분 있으면 말씀 주세여~!