### PR TITLE
Feature 87 모각코 참여 참여취소 구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -2,9 +2,13 @@ package org.prgms.locomocoserver.mogakkos.application;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
+import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
+import org.prgms.locomocoserver.user.application.UserService;
+import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,7 +16,8 @@ import org.springframework.stereotype.Service;
 public class MogakkoParticipationService {
 
     private final ParticipantRepository participantRepository;
-
+    private final MogakkoService mogakkoService;
+    private final UserService userService;
 
     public ParticipationCheckingDto check(Long mogakkoId, Long userId) {
         Optional<Participant> optionalParticipant = participantRepository.findByMogakkoIdAndUserId(
@@ -23,5 +28,14 @@ public class MogakkoParticipationService {
         }
 
         return new ParticipationCheckingDto(false);
+    }
+
+    public void participate(Long mogakkoId, ParticipationRequestDto requestDto) {
+        Mogakko mogakko = mogakkoService.getByIdNotDeleted(mogakkoId);
+        User user = userService.getById(requestDto.userId());
+
+        Participant participant = Participant.builder().mogakko(mogakko).user(user).build();
+        mogakko.addParticipant(participant);
+        participantRepository.save(participant);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -1,0 +1,27 @@
+package org.prgms.locomocoserver.mogakkos.application;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
+import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
+import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MogakkoParticipationService {
+
+    private final ParticipantRepository participantRepository;
+
+
+    public ParticipationCheckingDto check(Long mogakkoId, Long userId) {
+        Optional<Participant> optionalParticipant = participantRepository.findByMogakkoIdAndUserId(
+            mogakkoId, userId);
+
+        if (optionalParticipant.isPresent()) {
+            return new ParticipationCheckingDto(true);
+        }
+
+        return new ParticipationCheckingDto(false);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepository.java
@@ -1,7 +1,8 @@
 package org.prgms.locomocoserver.mogakkos.domain.participants;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
-
+    Optional<Participant> findByMogakkoIdAndUserId(Long mogakkoId, Long userId);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.mogakkos.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ParticipationRequestDto(@Schema(description = "참여하고자 하는 유저 id", example = "1") Long userId) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/ParticipationCheckingDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/ParticipationCheckingDto.java
@@ -1,0 +1,5 @@
+package org.prgms.locomocoserver.mogakkos.dto.response;
+
+public record ParticipationCheckingDto(boolean isParticipated) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/ParticipationCheckingDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/ParticipationCheckingDto.java
@@ -1,5 +1,7 @@
 package org.prgms.locomocoserver.mogakkos.dto.response;
 
-public record ParticipationCheckingDto(boolean isParticipated) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ParticipationCheckingDto(@Schema(description = "참여 여부") boolean isParticipated) {
 
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
@@ -3,10 +3,13 @@ package org.prgms.locomocoserver.mogakkos.presentation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoParticipationService;
+import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,5 +28,13 @@ public class MogakkoParticipationController {
         ParticipationCheckingDto responseDto = participationService.check(id, userId);
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    @PostMapping("mogakko/map/{id}/participate")
+    public ResponseEntity<Void> participate(@PathVariable Long id,
+        @RequestBody ParticipationRequestDto requestDto) {
+        participationService.participate(id, requestDto);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
@@ -1,5 +1,9 @@
 package org.prgms.locomocoserver.mogakkos.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoParticipationService;
@@ -23,24 +27,40 @@ public class MogakkoParticipationController {
 
     private final MogakkoParticipationService participationService;
 
+    @Operation(summary = "모각코 참여 여부 확인", description = "어떤 모각코에 특정 유저가 참여 중인지를 확인할 수 있습니다.")
+    @ApiResponses(
+        @ApiResponse(responseCode = "200", description = "참여 확인 성공")
+    )
     @GetMapping("/mogakko/map/{id}/participate")
     public ResponseEntity<ParticipationCheckingDto> checkParticipating(
-        @PathVariable Long id, @RequestParam Long userId) {
+        @Parameter(description = "모각코 id", example = "1") @PathVariable Long id,
+        @Parameter(description = "참여 확인을 위한 유저 id", example = "2") @RequestParam Long userId) {
         ParticipationCheckingDto responseDto = participationService.check(id, userId);
 
         return ResponseEntity.ok(responseDto);
     }
 
+    @Operation(summary = "모각코 참여 신청", description = "어떤 모각코에 특정 유저가 참여를 신청합니다.")
+    @ApiResponses(
+        @ApiResponse(responseCode = "200", description = "참여 성공")
+    )
     @PostMapping("/mogakko/map/{id}/participate")
-    public ResponseEntity<Void> participate(@PathVariable Long id,
-        @RequestBody ParticipationRequestDto requestDto) {
+    public ResponseEntity<Void> participate(
+        @Parameter(description = "모각코 id", example = "1") @PathVariable Long id,
+        @Parameter(description = "참여를 원하는 유저 id") @RequestBody ParticipationRequestDto requestDto) {
         participationService.participate(id, requestDto);
 
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "모각코 참여 취소", description = "어떤 모각코에 참여 중인 특정 유저가 해당 모각코 참여를 취소합니다.")
+    @ApiResponses(
+        @ApiResponse(responseCode = "204", description = "참여 취소 성공")
+    )
     @DeleteMapping("/mogakko/map/{id}/participate")
-    public ResponseEntity<Void> cancel(@PathVariable Long id, @RequestParam Long userId) {
+    public ResponseEntity<Void> cancel(
+        @Parameter(description = "모각코 id", example = "1") @PathVariable Long id,
+        @Parameter(description = "참여 취소를 원하는 유저 id", example = "1") @RequestParam Long userId) {
         participationService.cancel(id, userId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
@@ -1,0 +1,29 @@
+package org.prgms.locomocoserver.mogakkos.presentation;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.mogakkos.application.MogakkoParticipationService;
+import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Mogakko Participation controller", description = "모각코 참여 컨트롤러")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MogakkoParticipationController {
+
+    private final MogakkoParticipationService participationService;
+
+    @GetMapping("mogakko/map/{id}/participate")
+    public ResponseEntity<ParticipationCheckingDto> checkParticipating(
+        @PathVariable Long id, @RequestParam Long userId) {
+        ParticipationCheckingDto responseDto = participationService.check(id, userId);
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
@@ -6,6 +6,7 @@ import org.prgms.locomocoserver.mogakkos.application.MogakkoParticipationService
 import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,7 +23,7 @@ public class MogakkoParticipationController {
 
     private final MogakkoParticipationService participationService;
 
-    @GetMapping("mogakko/map/{id}/participate")
+    @GetMapping("/mogakko/map/{id}/participate")
     public ResponseEntity<ParticipationCheckingDto> checkParticipating(
         @PathVariable Long id, @RequestParam Long userId) {
         ParticipationCheckingDto responseDto = participationService.check(id, userId);
@@ -30,11 +31,18 @@ public class MogakkoParticipationController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @PostMapping("mogakko/map/{id}/participate")
+    @PostMapping("/mogakko/map/{id}/participate")
     public ResponseEntity<Void> participate(@PathVariable Long id,
         @RequestBody ParticipationRequestDto requestDto) {
         participationService.participate(id, requestDto);
 
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/mogakko/map/{id}/participate")
+    public ResponseEntity<Void> cancel(@PathVariable Long id, @RequestParam Long userId) {
+        participationService.cancel(id, userId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepositoryTest.java
@@ -1,0 +1,60 @@
+package org.prgms.locomocoserver.mogakkos.domain.participants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.user.domain.User;
+import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.prgms.locomocoserver.user.domain.enums.Gender;
+import org.prgms.locomocoserver.user.domain.enums.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ParticipantRepositoryTest {
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+    @Autowired
+    private MogakkoRepository mogakkoRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("모각코 id와 유저 id를 이용해 특정 유저가 특정 모각코에 참여 중인지 확인할 수 있다")
+    void success_find_by_mogakko_and_user() {
+        // given
+        User creator = User.builder().email("creator@gmail.com").nickname("creator").temperature(36.5)
+            .birth(LocalDate.EPOCH).job(Job.JOB_SEEKER).gender(Gender.MALE).provider("kakao")
+            .build();
+        User user = User.builder().email("email@gmail.com").nickname("temp").temperature(36.5)
+            .birth(LocalDate.EPOCH).job(Job.ETC).gender(Gender.MALE).provider("kakao")
+            .build();
+        Mogakko mogakko = Mogakko.builder().title("title").startTime(LocalDateTime.now())
+            .endTime(LocalDateTime.now()).deadline(LocalDateTime.now()).content("content")
+            .maxParticipants(8).likeCount(0).creator(creator)
+            .build();
+        Participant participant = Participant.builder().mogakko(mogakko).user(user)
+            .build();
+        mogakko.addParticipant(participant);
+
+        userRepository.saveAll(List.of(creator, user));
+        mogakkoRepository.save(mogakko);
+        participantRepository.save(participant);
+
+        // when
+        Optional<Participant> retrievedParticipant = participantRepository.findByMogakkoIdAndUserId(
+            mogakko.getId(), user.getId());
+
+        assertThat(retrievedParticipant.isPresent()).isTrue();
+        assertThat(retrievedParticipant.get().getUser()).isSameAs(user);
+
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #87 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
참여 조회, 참여 신청, 참여 취소를 구현했습니다. 각각 클라이언트로부터 모각코 id와 유저 id를 받아와 참여를 매핑합니다.
아주 간단한 검증만 되어 있습니다. deadline이 지난 모각코면 참여 신청할 수 없고 endTime이 지난 모각코면 참여 취소할 수 없습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
좀 길긴 한데 우리가 아는 CRUD입니다. 검증 부분은 따로 이슈처리 했으나 검증해야 할 상황 같은 것이 따로 있다고 느껴지시면 남겨주시면 감사하겠습니다~~~~~~~~~~~~~~~~!!