### PR TITLE
Feature 124 모각코 생성 후 채팅방 자동 생성

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -13,7 +13,6 @@ import org.prgms.locomocoserver.chat.dto.ChatRoomDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatCreateRequestDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatEnterRequestDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatMessageRequestDto;
-import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.stereotype.Service;
@@ -25,7 +24,6 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final MogakkoService mogakkoService;
     private final UserService userService;
     private final StompChatService stompChatService;
 

--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -115,7 +115,9 @@ public class ChatRoomService {
             .chatRoom(chatRoom).build());
 
         chatRoom.addChatParticipant(chatParticipant);
+        chatRoomRepository.save(chatRoom);
+        chatMessageRepository.save(toEnterMessage(chatRoom, requestDto.creator()));
 
-        return chatRoomRepository.save(chatRoom);
+        return chatRoom;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -1,5 +1,8 @@
 package org.prgms.locomocoserver.chat.application;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.chat.domain.ChatMessage;
 import org.prgms.locomocoserver.chat.domain.ChatMessageRepository;
@@ -7,17 +10,13 @@ import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.chat.dto.ChatMessageDto;
 import org.prgms.locomocoserver.chat.dto.ChatRoomDto;
+import org.prgms.locomocoserver.chat.dto.request.ChatCreateRequestDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatMessageRequestDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
-import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +30,7 @@ public class ChatRoomService {
 
     @Transactional
     public ChatRoomDto enterChatRoom(ChatMessageRequestDto requestDto) {
-        ChatRoom chatRoom = chatRoomRepository.findByIdAndDeletedAtIsNull(requestDto.chatRoomId())
-                .orElseGet(() -> createChatRoom(requestDto));
+        ChatRoom chatRoom = getById(requestDto.chatRoomId());
 
         if (!isParticipantExist(chatRoom, requestDto.senderId())) {
             ChatMessageDto chatMessageDto = saveEnterMessage(requestDto);
@@ -107,12 +105,9 @@ public class ChatRoomService {
         return chatMessageRepository.findLastMessageByRoomId(roomId);
     }
 
-    private ChatRoom createChatRoom(ChatMessageRequestDto messageRequestDto) {
-        User loginUser = userService.getById(messageRequestDto.senderId());
-        Mogakko mogakko = mogakkoService.getByIdNotDeleted(messageRequestDto.mogakkoId());
+    public ChatRoom createChatRoom(ChatCreateRequestDto requestDto) {
+        ChatRoom chatRoom = chatRoomRepository.save(requestDto.toChatRoomEntity());
 
-        ChatRoom chatRoom = chatRoomRepository.save(messageRequestDto.toChatRoomEntity(mogakko, loginUser));
-        chatMessageRepository.save(messageRequestDto.toChatMessageEntity(loginUser, chatRoom));
         return chatRoom;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -28,7 +28,7 @@ public class ChatRoomService {
     private final StompChatService stompChatService;
 
     @Transactional
-    public ChatRoomDto enterChatRoom(ChatEnterRequestDto requestDto) {
+    public void enterChatRoom(ChatEnterRequestDto requestDto) {
         ChatRoom chatRoom = getById(requestDto.chatRoomId());
 
         if (!isParticipantExist(chatRoom, requestDto.participant())) {
@@ -36,8 +36,6 @@ public class ChatRoomService {
             chatRoom.addParticipant(requestDto.participant());
             stompChatService.sendToSubscribers(chatMessageDto);
         }
-
-        return ChatRoomDto.of(chatRoom, ChatMessageDto.of(getLastMessage(chatRoom.getId())));
     }
 
     @Transactional

--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -102,9 +102,11 @@ public class ChatRoomService {
         return chatMessageRepository.findLastMessageByRoomId(roomId);
     }
 
+    @Transactional
     public ChatRoom createChatRoom(ChatCreateRequestDto requestDto) {
-        ChatRoom chatRoom = chatRoomRepository.save(requestDto.toChatRoomEntity());
+        ChatRoom chatRoom = requestDto.toChatRoomEntity();
+        chatRoom.addParticipant(requestDto.creator());
 
-        return chatRoom;
+        return chatRoomRepository.save(chatRoom);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatParticipant.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatParticipant.java
@@ -1,0 +1,39 @@
+package org.prgms.locomocoserver.chat.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prgms.locomocoserver.user.domain.User;
+
+@Entity
+@Getter
+@Table(name = "chat_participants")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+
+    @Builder
+    public ChatParticipant(User user, ChatRoom chatRoom) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatParticipantRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatParticipantRepository.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.chat.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoom.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoom.java
@@ -1,6 +1,7 @@
 package org.prgms.locomocoserver.chat.domain;
 
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,24 +35,23 @@ public class ChatRoom extends BaseEntity {
     @JoinColumn(name = "creator_id", referencedColumnName = "id", nullable = false)
     private User creator;
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(name = "chat_rooms_participants",
-            joinColumns = @JoinColumn(name = "chat_room_id"),
-            inverseJoinColumns = @JoinColumn(name = "participants_id"),
-            uniqueConstraints = @UniqueConstraint(columnNames = {"chat_room_id", "participants_id"}))
+    @OneToMany(mappedBy = "chatRoom")
     @Builder.Default
-    private List<User> participants = new ArrayList<>();
+    private List<ChatParticipant> chatParticipants = new ArrayList<>();
 
-    public ChatRoom(Long id, String name, Mogakko mogakko, User creator, List<User> participants) {
+    public ChatRoom(Long id, String name, Mogakko mogakko, User creator, List<ChatParticipant> chatParticipants) {
         this.id = id;
         this.name = name;
         this.mogakko = mogakko;
         this.creator = creator;
-        this.participants = participants;
+        this.chatParticipants = chatParticipants;
     }
 
-    public void addParticipant(User user) {
-        this.participants.add(user);
-        user.getChatRoomList().add(this);
+    public void addChatParticipant(ChatParticipant participant) {
+        if (Objects.nonNull(participant)) {
+            this.chatParticipants.remove(participant);
+        }
+
+        this.chatParticipants.add(participant);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoom.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoom.java
@@ -26,7 +26,7 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mogakko_id", nullable = false, unique = true)
     private Mogakko mogakko;
 

--- a/src/main/java/org/prgms/locomocoserver/chat/dto/ChatRoomDto.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/dto/ChatRoomDto.java
@@ -1,11 +1,8 @@
 package org.prgms.locomocoserver.chat.dto;
 
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 public record ChatRoomDto(
         Long roomId,
@@ -16,6 +13,6 @@ public record ChatRoomDto(
         ChatMessageDto lastMessage
 ) {
     public static ChatRoomDto of(ChatRoom chatRoom, ChatMessageDto lastMessage) {
-        return new ChatRoomDto(chatRoom.getId(), chatRoom.getName(), chatRoom.getParticipants().size(), chatRoom.getCreatedAt(), chatRoom.getUpdatedAt(), lastMessage);
+        return new ChatRoomDto(chatRoom.getId(), chatRoom.getName(), chatRoom.getChatParticipants().size(), chatRoom.getCreatedAt(), chatRoom.getUpdatedAt(), lastMessage);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatCreateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatCreateRequestDto.java
@@ -1,0 +1,16 @@
+package org.prgms.locomocoserver.chat.dto.request;
+
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.user.domain.User;
+
+public record ChatCreateRequestDto(Mogakko mogakko, User creator) {
+
+    public ChatRoom toChatRoomEntity() {
+        return ChatRoom.builder()
+            .name(mogakko.getTitle())
+            .mogakko(mogakko)
+            .creator(creator)
+            .build();
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatEnterRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatEnterRequestDto.java
@@ -1,0 +1,8 @@
+package org.prgms.locomocoserver.chat.dto.request;
+
+import org.prgms.locomocoserver.user.domain.User;
+
+public record ChatEnterRequestDto(Long chatRoomId,
+                                  User participant) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatMessageRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatMessageRequestDto.java
@@ -3,11 +3,7 @@ package org.prgms.locomocoserver.chat.dto.request;
 import lombok.NonNull;
 import org.prgms.locomocoserver.chat.domain.ChatMessage;
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
-import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.user.domain.User;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public record ChatMessageRequestDto(
         @NonNull
@@ -18,20 +14,11 @@ public record ChatMessageRequestDto(
         Long senderId,
         String message // TODO: 글자수 초과 시 예외 처리
 ) {
-
-    public ChatRoom toChatRoomEntity(Mogakko mogakko, User creator) {
-        return ChatRoom.builder()
-                .name(mogakko.getTitle())
-                .mogakko(mogakko)
-                .creator(creator)
-                .build();
-    }
-
     public ChatMessage toChatMessageEntity(User sender, ChatRoom chatRoom) {
         return ChatMessage.builder()
-                .sender(sender)
-                .chatRoom(chatRoom)
-                .content(message).build();
+            .sender(sender)
+            .chatRoom(chatRoom)
+            .content(message).build();
     }
 
     public ChatMessage toEnterMessageEntity(User sender, ChatRoom chatRoom) {

--- a/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatMessageRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/dto/request/ChatMessageRequestDto.java
@@ -21,11 +21,4 @@ public record ChatMessageRequestDto(
             .content(message).build();
     }
 
-    public ChatMessage toEnterMessageEntity(User sender, ChatRoom chatRoom) {
-        return ChatMessage.builder()
-                .sender(sender)
-                .chatRoom(chatRoom)
-                .content(sender.getNickname() + " 님이 채팅방에 입장하였습니다.").build();
-    }
-
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/presentation/StompChatController.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/presentation/StompChatController.java
@@ -4,19 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.chat.application.ChatRoomService;
 import org.prgms.locomocoserver.chat.application.StompChatService;
-import org.prgms.locomocoserver.chat.domain.ChatMessageRepository;
-import org.prgms.locomocoserver.chat.domain.ChatRoom;
-import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.chat.dto.ChatMessageDto;
-import org.prgms.locomocoserver.chat.dto.ChatRoomDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatMessageRequestDto;
-import org.prgms.locomocoserver.user.application.UserService;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Optional;
 
 @Slf4j
 @RestController
@@ -25,12 +16,6 @@ public class StompChatController {
 
     private final ChatRoomService chatRoomService;
     private final StompChatService stompChatService;
-
-    @MessageMapping(value = "/chats/enter")
-    public void enter(ChatMessageRequestDto requestDto) {
-        ChatRoomDto chatRoomDto = chatRoomService.enterChatRoom(requestDto);
-        log.info("Entered ChatRoomId: " + chatRoomDto.roomId());
-    }
 
     @MessageMapping(value = "/chats/message")
     public void message(ChatMessageRequestDto requestDto) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -3,6 +3,8 @@ package org.prgms.locomocoserver.mogakkos.application;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.chat.application.ChatRoomService;
+import org.prgms.locomocoserver.chat.dto.request.ChatEnterRequestDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
@@ -19,6 +21,7 @@ public class MogakkoParticipationService {
     private final ParticipantRepository participantRepository;
     private final MogakkoService mogakkoService;
     private final UserService userService;
+    private final ChatRoomService chatRoomService;
 
     public ParticipationCheckingDto check(Long mogakkoId, Long userId) {
         Optional<Participant> optionalParticipant = participantRepository.findByMogakkoIdAndUserId(
@@ -40,9 +43,11 @@ public class MogakkoParticipationService {
         Participant participant = Participant.builder().mogakko(mogakko).user(user).build();
         mogakko.addParticipant(participant);
         participantRepository.save(participant);
+
+        chatRoomService.enterChatRoom(new ChatEnterRequestDto(mogakko.getChatRoom().getId(), user));
     }
 
-    public void cancel(Long mogakkoId, Long userId) {
+    public void cancel(Long mogakkoId, Long userId) { // TODO: 참여 취소 시 채팅방 자동 나가기
         Mogakko mogakko = mogakkoService.getByIdNotDeleted(mogakkoId);
 
         validateIfEndTimeIsPast(mogakko);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -47,6 +47,7 @@ public class MogakkoService {
     private final MogakkoTagRepository mogakkoTagRepository;
     private final ChatRoomService chatRoomService;
 
+    @Transactional
     public Long save(MogakkoCreateRequestDto requestDto) {
         Mogakko mogakko = createMogakkoBy(requestDto);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -3,23 +3,26 @@ package org.prgms.locomocoserver.mogakkos.application;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.chat.application.ChatRoomService;
+import org.prgms.locomocoserver.chat.dto.request.ChatCreateRequestDto;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
-import org.prgms.locomocoserver.mogakkos.domain.likes.MogakkoLike;
-import org.prgms.locomocoserver.mogakkos.domain.likes.MogakkoLikeRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
-import org.prgms.locomocoserver.mogakkos.dto.response.*;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoParticipantDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
 import org.prgms.locomocoserver.user.application.UserService;
@@ -27,10 +30,7 @@ import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.prgms.locomocoserver.user.dto.response.UserBriefInfoDto;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +45,7 @@ public class MogakkoService {
     private final UserService userService;
     private final LocationRepository locationRepository;
     private final MogakkoTagRepository mogakkoTagRepository;
-    private final MogakkoLikeRepository likeRepository;
+    private final ChatRoomService chatRoomService;
 
     public Long save(MogakkoCreateRequestDto requestDto) {
         Mogakko mogakko = createMogakkoBy(requestDto);
@@ -58,6 +58,8 @@ public class MogakkoService {
 
         Mogakko savedMogakko = mogakkoRepository.save(mogakko);
         locationRepository.save(location);
+
+        chatRoomService.createChatRoom(new ChatCreateRequestDto(savedMogakko, creator));
 
         return savedMogakko.getId();
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -86,7 +86,7 @@ public class Mogakko extends BaseEntity {
     public Mogakko(Long id, String title, String content, LocalDateTime startTime,
         LocalDateTime endTime, LocalDateTime deadline, int likeCount, int maxParticipants,
         long views, List<MogakkoTag> mogakkoTags, List<Participant> participants,
-        List<Inquiry> inquiries, User creator) {
+        List<Inquiry> inquiries, User creator, ChatRoom chatRoom) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -100,6 +100,7 @@ public class Mogakko extends BaseEntity {
         this.participants = participants;
         this.inquiries = inquiries;
         this.creator = creator;
+        this.chatRoom = chatRoom;
     }
 
     public void addMogakkoTag(MogakkoTag mogakkoTag) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.global.common.BaseEntity;
 import org.prgms.locomocoserver.inquiries.domain.Inquiry;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
@@ -78,6 +80,9 @@ public class Mogakko extends BaseEntity {
     @JoinColumn(name = "creator_id", nullable = false)
     private User creator;
 
+    @OneToOne(mappedBy = "mogakko")
+    private ChatRoom chatRoom;
+
     public Mogakko(Long id, String title, String content, LocalDateTime startTime,
         LocalDateTime endTime, LocalDateTime deadline, int likeCount, int maxParticipants,
         long views, List<MogakkoTag> mogakkoTags, List<Participant> participants,
@@ -111,6 +116,10 @@ public class Mogakko extends BaseEntity {
 
     public void updateCreator(User creator) {
         this.creator = creator;
+    }
+
+    public void updateChatRoom(ChatRoom chatRoom) {
+        this.chatRoom = chatRoom;
     }
 
     public boolean isSameCreatorId(Long creatorId) {

--- a/src/main/java/org/prgms/locomocoserver/user/domain/User.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/User.java
@@ -18,18 +18,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.prgms.locomocoserver.chat.domain.ChatParticipant;
 import org.prgms.locomocoserver.global.common.BaseEntity;
 import org.prgms.locomocoserver.image.domain.Image;
 import org.prgms.locomocoserver.user.domain.enums.Gender;
 import org.prgms.locomocoserver.user.domain.enums.Job;
-import org.prgms.locomocoserver.chat.domain.ChatParticipant;
 import org.prgms.locomocoserver.user.dto.request.UserUpdateRequest;
-import org.prgms.locomocoserver.user.vo.EmailVo;
-import org.prgms.locomocoserver.user.vo.TemperatureVo;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/org/prgms/locomocoserver/user/domain/User.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/User.java
@@ -1,21 +1,28 @@
 package org.prgms.locomocoserver.user.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.prgms.locomocoserver.chat.domain.ChatRoom;
+import org.prgms.locomocoserver.chat.domain.ChatParticipant;
 import org.prgms.locomocoserver.global.common.BaseEntity;
 import org.prgms.locomocoserver.image.domain.Image;
 import org.prgms.locomocoserver.user.domain.enums.Gender;
 import org.prgms.locomocoserver.user.domain.enums.Job;
-import org.prgms.locomocoserver.user.vo.EmailVo;
-import org.prgms.locomocoserver.user.vo.TemperatureVo;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -54,11 +61,13 @@ public class User extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private Image profileImage;
 
-    @ManyToMany(fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user")
     @Builder.Default
-    private List<ChatRoom> chatRoomList = new ArrayList<>();
+    private List<ChatParticipant> chatRooms = new ArrayList<>();
 
-    public User(Long id, String nickname, LocalDate birth, Gender gender, double temperature, Job job, String email, String provider, Image profileImage, List<ChatRoom> chatRoomList) {
+    public User(Long id, String nickname, LocalDate birth, Gender gender, double temperature,
+        Job job, String email, String provider, Image profileImage,
+        List<ChatParticipant> chatRooms) {
         this.id = id;
         this.nickname = nickname;
         this.birth = birth;
@@ -68,7 +77,7 @@ public class User extends BaseEntity {
         this.email = email;
         this.provider = provider;
         this.profileImage = profileImage;
-        this.chatRoomList = chatRoomList;
+        this.chatRooms = chatRooms;
     }
 
     public void setInitInfo(String nickname, LocalDate birth, Gender gender, Job job) {

--- a/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
@@ -7,8 +7,10 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.chat.dto.request.ChatEnterRequestDto;
@@ -16,6 +18,7 @@ import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
@@ -39,6 +42,18 @@ class ChatRoomServiceTest {
     private MogakkoService mogakkoService;
     @Autowired
     private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private MogakkoRepository mogakkoRepository;
+    @Autowired
+    private ChatParticipantRepository chatParticipantRepository;
+
+    @AfterEach
+    void tearDown() {
+        chatParticipantRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        mogakkoRepository.deleteAll();
+        userRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("채팅방에 참여할 수 있다")
@@ -71,6 +86,6 @@ class ChatRoomServiceTest {
 
         assertThat(chatRoom.getMogakko().getId()).isEqualTo(mogakkoId);
         assertThat(chatRoom.getCreator().getId()).isEqualTo(dummyUsers.get(0).getId());
-        assertThat(chatRoom.getParticipants()).hasSize(3);
+        assertThat(chatRoom.getChatParticipants()).hasSize(3);
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
@@ -22,6 +22,7 @@ import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.prgms.locomocoserver.user.domain.enums.Gender;
@@ -76,12 +77,13 @@ class ChatRoomServiceTest {
 
         Location location = Location.builder().city("Carry You").address("Martin Garrix")
             .latitude(10.233214).longitude(23.312314).build();
-        Long mogakkoId = mogakkoService.save(
-            new MogakkoCreateRequestDto(dummyUsers.get(0).getId(), "title", LocationInfoDto.create(location),
+        MogakkoCreateResponseDto responseDto = mogakkoService.save(
+            new MogakkoCreateRequestDto(dummyUsers.get(0).getId(), "title",
+                LocationInfoDto.create(location),
                 LocalDateTime.now(), LocalDateTime.now().plusHours(2),
                 LocalDateTime.now().plusHours(1),
                 10, "", List.of()));
-        Mogakko mogakko = mogakkoService.getByIdNotDeleted(mogakkoId);
+        Mogakko mogakko = mogakkoService.getByIdNotDeleted(responseDto.id());
 
         // when
         chatRoomService.enterChatRoom(new ChatEnterRequestDto(mogakko.getChatRoom().getId(), dummyUsers.get(1)));
@@ -93,7 +95,7 @@ class ChatRoomServiceTest {
         ChatRoom chatRoom = chatRoomRepository.findByIdAndDeletedAtIsNull(
             mogakko.getChatRoom().getId()).orElseThrow(RuntimeException::new);
 
-        assertThat(chatRoom.getMogakko().getId()).isEqualTo(mogakkoId);
+        assertThat(chatRoom.getMogakko().getId()).isEqualTo(mogakko.getId());
         assertThat(chatRoom.getCreator().getId()).isEqualTo(dummyUsers.get(0).getId());
         assertThat(chatRoom.getChatParticipants()).hasSize(3);
 

--- a/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
@@ -71,6 +71,6 @@ class ChatRoomServiceTest {
 
         assertThat(chatRoom.getMogakko().getId()).isEqualTo(mogakkoId);
         assertThat(chatRoom.getCreator().getId()).isEqualTo(dummyUsers.get(0).getId());
-        assertThat(chatRoom.getParticipants()).hasSize(2);
+        assertThat(chatRoom.getParticipants()).hasSize(3);
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
@@ -1,0 +1,76 @@
+package org.prgms.locomocoserver.chat.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
+import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
+import org.prgms.locomocoserver.chat.dto.request.ChatEnterRequestDto;
+import org.prgms.locomocoserver.location.domain.Location;
+import org.prgms.locomocoserver.location.dto.LocationInfoDto;
+import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.user.domain.User;
+import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.prgms.locomocoserver.user.domain.enums.Gender;
+import org.prgms.locomocoserver.user.domain.enums.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+@SpringBootTest
+class ChatRoomServiceTest {
+
+    @Autowired
+    private PlatformTransactionManager tx;
+    @Autowired
+    private ChatRoomService chatRoomService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MogakkoService mogakkoService;
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Test
+    @DisplayName("채팅방에 참여할 수 있다")
+    void success_enter_chat_room_as_participant() {
+        // given
+        List<User> dummyUsers = new ArrayList<>();
+        IntStream.rangeClosed(0, 2).forEach(i -> dummyUsers.add(
+            User.builder().nickname("name" + i).email(i + "email@gmail.com").birth(LocalDate.EPOCH)
+                .temperature(36.5).provider("kakao").gender(Gender.MALE).job(Job.ETC).build()));
+        userRepository.saveAll(dummyUsers);
+
+        Location location = Location.builder().city("Carry You").address("Martin Garrix")
+            .latitude(10.233214).longitude(23.312314).build();
+        Long mogakkoId = mogakkoService.save(
+            new MogakkoCreateRequestDto(dummyUsers.get(0).getId(), "title", LocationInfoDto.create(location),
+                LocalDateTime.now(), LocalDateTime.now().plusHours(2),
+                LocalDateTime.now().plusHours(1),
+                10, "", List.of()));
+        Mogakko mogakko = mogakkoService.getByIdNotDeleted(mogakkoId);
+
+        // when
+        chatRoomService.enterChatRoom(new ChatEnterRequestDto(mogakko.getChatRoom().getId(), dummyUsers.get(1)));
+        chatRoomService.enterChatRoom(new ChatEnterRequestDto(mogakko.getChatRoom().getId(), dummyUsers.get(2)));
+
+        // then
+        tx.getTransaction(new DefaultTransactionDefinition());
+
+        ChatRoom chatRoom = chatRoomRepository.findByIdAndDeletedAtIsNull(
+            mogakko.getChatRoom().getId()).orElseThrow(RuntimeException::new);
+
+        assertThat(chatRoom.getMogakko().getId()).isEqualTo(mogakkoId);
+        assertThat(chatRoom.getCreator().getId()).isEqualTo(dummyUsers.get(0).getId());
+        assertThat(chatRoom.getParticipants()).hasSize(2);
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -26,6 +26,7 @@ import org.prgms.locomocoserver.categories.domain.Category;
 import org.prgms.locomocoserver.categories.domain.CategoryInputType;
 import org.prgms.locomocoserver.categories.domain.CategoryRepository;
 import org.prgms.locomocoserver.categories.domain.CategoryType;
+import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
 import org.prgms.locomocoserver.location.dto.LocationInfoDto;
@@ -70,6 +71,8 @@ class MogakkoServiceTest {
     private ParticipantRepository participantRepository;
     @Autowired
     private LocationRepository locationRepository;
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
     private User setUpUser1, setUpUser2;
     private Mogakko testMogakko;
 
@@ -123,6 +126,7 @@ class MogakkoServiceTest {
         participantRepository.deleteAll();
         mogakkoTagRepository.deleteAll();
         locationRepository.deleteAll();
+        chatRoomRepository.deleteAll();
         mogakkoRepository.deleteAll();
         userRepository.deleteAll();
         tagRepository.deleteAll();
@@ -162,6 +166,7 @@ class MogakkoServiceTest {
         assertThat(createdMogakko.getMaxParticipants()).isEqualTo(Mogakko.DEFAULT_MAX_PARTICIPANTS);
         assertThat(createdMogakko.getViews()).isEqualTo(0);
         assertThat(createdMogakko.getCreator().getId()).isEqualTo(savedCreator.getId());
+        assertThat(createdMogakko.getChatRoom()).isNotNull();
 
         assertThat(mogakkoTagRepository.findAllByMogakko(createdMogakko)).hasSize(3);
     }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -26,6 +26,8 @@ import org.prgms.locomocoserver.categories.domain.Category;
 import org.prgms.locomocoserver.categories.domain.CategoryInputType;
 import org.prgms.locomocoserver.categories.domain.CategoryRepository;
 import org.prgms.locomocoserver.categories.domain.CategoryType;
+import org.prgms.locomocoserver.chat.domain.ChatMessageRepository;
+import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
 import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
@@ -73,6 +75,10 @@ class MogakkoServiceTest {
     private LocationRepository locationRepository;
     @Autowired
     private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private ChatParticipantRepository chatParticipantRepository;
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
     private User setUpUser1, setUpUser2;
     private Mogakko testMogakko;
 
@@ -123,9 +129,11 @@ class MogakkoServiceTest {
 
     @AfterAll
     void tearDown() {
+        chatMessageRepository.deleteAll();
         participantRepository.deleteAll();
         mogakkoTagRepository.deleteAll();
         locationRepository.deleteAll();
+        chatParticipantRepository.deleteAll();
         chatRoomRepository.deleteAll();
         mogakkoRepository.deleteAll();
         userRepository.deleteAll();

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepositoryTest.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
@@ -26,6 +27,13 @@ class ParticipantRepositoryTest {
     private MogakkoRepository mogakkoRepository;
     @Autowired
     private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        participantRepository.deleteAll();
+        mogakkoRepository.deleteAll();
+        userRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("모각코 id와 유저 id를 이용해 특정 유저가 특정 모각코에 참여 중인지 확인할 수 있다")


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #124 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
기존 채팅-채팅방 참여 유저 사이 `ManyToMany`가 테스트 코드에서 말썽을 일으켜 삭제하고 `ChatParticipant`라는 중간 테이블 엔티티를 생성하였습니다!

모각코 생성이 되면 이제 자동으로 채팅방이 생성되고 생성자는 자동 참여됩니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
* 중간 테이블 엔티티를 만들면서 조금 문제가 있을 수도 있을 거 같아서 `ChatRoom`, `ChatMessage`, `User`, `ChatParticipant` 등 채팅 관련 도메인 사이 문제가 없을지 확인해주시면 감사하겠습니다!
* 모각코 생성 시 채팅 자동 참여, 모각코 참여 시 채팅 자동 참여 부분도 확인해주시면 좋을 것 같아요!