### PR TITLE
Feature 130 마이페이지 모각코 목록 개수만 넘겨주고 모각코 목록 dto는 간소화

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/likes/MogakkoLikeRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/likes/MogakkoLikeRepository.java
@@ -6,9 +6,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MogakkoLikeRepository extends JpaRepository<MogakkoLike, Long> {
     Optional<MogakkoLike> findByMogakkoAndUser(Mogakko mogakko, User user);
     boolean existsByMogakkoAndUser(Mogakko mogakko, User user);
     List<MogakkoLike> findAllByUser(User user); // TODO: 페이징 처리
+    @Query("SELECT COUNT(ml.id) FROM MogakkoLike ml INNER JOIN Mogakko m "
+        + "ON ml.user = :user AND m.deletedAt IS NULL AND ml.mogakko = m")
+    long countByUser(User user);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/ParticipantRepository.java
@@ -1,8 +1,19 @@
 package org.prgms.locomocoserver.mogakkos.domain.participants;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     Optional<Participant> findByMogakkoIdAndUserId(Long mogakkoId, Long userId);
+
+    @Query("SELECT COUNT(p.id) FROM Participant p INNER JOIN Mogakko m "
+        + "ON p.user = :user AND m.endTime >= :time AND p.mogakko = m AND m.deletedAt IS NULL")
+    long countOngoingByUser(User user, LocalDateTime time);
+
+    @Query("SELECT COUNT(p.id) FROM Participant p INNER JOIN Mogakko m "
+        + "ON p.user = :user AND m.endTime < :time AND p.mogakko = m AND m.deletedAt IS NULL")
+    long countCompleteByUser(User user, LocalDateTime time);
 }

--- a/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
@@ -1,5 +1,9 @@
 package org.prgms.locomocoserver.user.application;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.image.application.ImageService;
@@ -9,13 +13,10 @@ import org.prgms.locomocoserver.image.exception.ImageErrorType;
 import org.prgms.locomocoserver.image.exception.ImageException;
 import org.prgms.locomocoserver.location.domain.Location;
 import org.prgms.locomocoserver.location.domain.LocationRepository;
-import org.prgms.locomocoserver.location.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.likes.MogakkoLikeRepository;
-import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
-import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
@@ -34,11 +35,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserService {
@@ -46,7 +42,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final MogakkoRepository mogakkoRepository;
     private final LocationRepository locationRepository;
-    private final MogakkoTagRepository mogakkoTagRepository;
     private final MogakkoLikeRepository mogakkoLikeRepository;
     private final ParticipantRepository participantRepository;
     private final ImageService imageService;
@@ -109,28 +104,26 @@ public class UserService {
         return UserMyPageDto.create(user, likeMogakkoCount, ongoingCount, completeCount);
     }
 
-    public List<MogakkoInfoDto> getOngoingMogakkos(Long userId) {
+    public List<MogakkoSimpleInfoResponseDto> getOngoingMogakkos(Long userId) {
         User user = getById(userId);
-        List<MogakkoInfoDto> mogakkoInfoDtos = mogakkoRepository.findOngoingMogakkosByUser(user, LocalDateTime.now())
-                .stream().map(mogakko -> {
-                    LocationInfoDto locationInfoDto = LocationInfoDto.create(locationRepository.findByMogakkoAndDeletedAtIsNull(mogakko).orElseThrow(() -> new IllegalArgumentException("Not Found Location")));
-                    List<Long> mogakkoTagIds = mogakkoTagRepository.findAllByMogakko(mogakko)
-                            .stream().map(mogakkoTag -> mogakkoTag.getId()).toList();  // TODO: List<Long> -> List<MogakkoTags> 변환되면 수정
-                    return MogakkoInfoDto.create(mogakko, locationInfoDto, mogakkoTagIds);
-                }).toList();
+        List<MogakkoSimpleInfoResponseDto> mogakkoInfoDtos = mogakkoRepository.findOngoingMogakkosByUser(user, LocalDateTime.now())
+            .stream().map(mogakko -> {
+                Location location = locationRepository.findByMogakkoAndDeletedAtIsNull(mogakko)
+                    .orElseThrow(() -> new IllegalArgumentException("Not Found Location"));
+                return MogakkoSimpleInfoResponseDto.create(mogakko, location);
+            }).toList();
 
         return mogakkoInfoDtos;
     }
 
-    public List<MogakkoInfoDto> getCompletedMogakkos(Long userId) {
+    public List<MogakkoSimpleInfoResponseDto> getCompletedMogakkos(Long userId) {
         User user = getById(userId);
-        List<MogakkoInfoDto> mogakkoInfoDtos = mogakkoRepository.findCompletedMogakkosByUser(user, LocalDateTime.now())
-                .stream().map(mogakko -> {
-                    LocationInfoDto locationInfoDto = LocationInfoDto.create(locationRepository.findByMogakkoAndDeletedAtIsNull(mogakko).orElseThrow(() -> new IllegalArgumentException("Not Found Location")));
-                    List<Long> mogakkoTagIds = mogakkoTagRepository.findAllByMogakko(mogakko)
-                            .stream().map(mogakkoTag -> mogakkoTag.getId()).toList();  // TODO: List<Long> -> List<MogakkoTags> 변환되면 수정
-                    return MogakkoInfoDto.create(mogakko, locationInfoDto, mogakkoTagIds);
-                }).toList();
+        List<MogakkoSimpleInfoResponseDto> mogakkoInfoDtos = mogakkoRepository.findCompletedMogakkosByUser(user, LocalDateTime.now())
+            .stream().map(mogakko -> {
+                Location location = locationRepository.findByMogakkoAndDeletedAtIsNull(mogakko)
+                    .orElseThrow(() -> new IllegalArgumentException("Not Found Location")); // TODO: 장소 에러 반환
+                return MogakkoSimpleInfoResponseDto.create(mogakko, location);
+            }).toList();
 
         return mogakkoInfoDtos;
     }

--- a/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
@@ -14,6 +14,7 @@ import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.likes.MogakkoLikeRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
+import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.user.domain.User;
@@ -26,6 +27,7 @@ import org.prgms.locomocoserver.user.dto.request.UserUpdateRequest;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
 import org.prgms.locomocoserver.user.dto.response.UserInfoDto;
 import org.prgms.locomocoserver.user.dto.response.UserLoginResponse;
+import org.prgms.locomocoserver.user.dto.response.UserMyPageDto;
 import org.prgms.locomocoserver.user.exception.UserErrorType;
 import org.prgms.locomocoserver.user.exception.UserException;
 import org.springframework.stereotype.Service;
@@ -46,6 +48,7 @@ public class UserService {
     private final LocationRepository locationRepository;
     private final MogakkoTagRepository mogakkoTagRepository;
     private final MogakkoLikeRepository mogakkoLikeRepository;
+    private final ParticipantRepository participantRepository;
     private final ImageService imageService;
 
     @Transactional
@@ -96,9 +99,14 @@ public class UserService {
         return UserInfoDto.of(user);
     }
 
-    public UserInfoDto getUserInfo(Long userId) {
+    public UserMyPageDto getUserInfo(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
         User user = getById(userId);
-        return UserInfoDto.of(user);
+        long likeMogakkoCount = mogakkoLikeRepository.countByUser(user);
+        long ongoingCount = participantRepository.countOngoingByUser(user, now);
+        long completeCount = participantRepository.countCompleteByUser(user, now);
+
+        return UserMyPageDto.create(user, likeMogakkoCount, ongoingCount, completeCount);
     }
 
     public List<MogakkoInfoDto> getOngoingMogakkos(Long userId) {

--- a/src/main/java/org/prgms/locomocoserver/user/dto/response/UserMyPageDto.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/response/UserMyPageDto.java
@@ -1,0 +1,17 @@
+package org.prgms.locomocoserver.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.prgms.locomocoserver.user.domain.User;
+
+public record UserMyPageDto(@Schema(description = "유저 정보") UserInfoDto userInfo,
+                            @Schema(description = "좋아요(찜) 모각코 개수") long likeMogakkoCount,
+                            @Schema(description = "진행중인 모각코 개수") long ongoingMogakkoCount,
+                            @Schema(description = "종료된 모각코 개수") long completeMogakkoCount) {
+
+    public static UserMyPageDto create(User user, long likeMogakkoCount, long ongoingMogakkoCount, long completeMogakkoCount) {
+        return new UserMyPageDto(UserInfoDto.of(user),
+            likeMogakkoCount,
+            ongoingMogakkoCount,
+            completeMogakkoCount);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
@@ -9,6 +9,7 @@ import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.dto.request.UserInitInfoRequestDto;
 import org.prgms.locomocoserver.user.dto.request.UserUpdateRequest;
 import org.prgms.locomocoserver.user.dto.response.UserInfoDto;
+import org.prgms.locomocoserver.user.dto.response.UserMyPageDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,9 +49,10 @@ public class UserController {
 
     @Operation(summary = "마이페이지 정보", description = "사용자 마이페이지 정보를 반환합니다.")
     @GetMapping("/users/{userId}")
-    public ResponseEntity<UserInfoDto> getUserInfo(@PathVariable Long userId) {
-        UserInfoDto userInfoDto = userService.getUserInfo(userId);
-        return ResponseEntity.ok(userInfoDto);
+    public ResponseEntity<UserMyPageDto> getUserInfo(@PathVariable Long userId) {
+        UserMyPageDto myPageDto = userService.getUserInfo(userId);
+
+        return ResponseEntity.ok(myPageDto);
     }
 
     @Operation(summary = "진행중인 모각코 목록 조회", description = "사용자가 진행중인 모각코 목록을 조회합니다.")

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
@@ -3,7 +3,6 @@ package org.prgms.locomocoserver.user.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.dto.request.UserInitInfoRequestDto;
@@ -57,15 +56,17 @@ public class UserController {
 
     @Operation(summary = "진행중인 모각코 목록 조회", description = "사용자가 진행중인 모각코 목록을 조회합니다.")
     @GetMapping("/users/{userId}/mogakko/ongoing")
-    public ResponseEntity<List<MogakkoInfoDto>> getOngoingMogakkos(@PathVariable Long userId) {
-        List<MogakkoInfoDto> mogakkoInfoDtos = userService.getOngoingMogakkos(userId);
+    public ResponseEntity<List<MogakkoSimpleInfoResponseDto>> getOngoingMogakkos(@PathVariable Long userId) {
+        List<MogakkoSimpleInfoResponseDto> mogakkoInfoDtos = userService.getOngoingMogakkos(userId);
+
         return ResponseEntity.ok(mogakkoInfoDtos);
     }
 
     @Operation(summary = "종료된 모각코 목록 조회", description = "사용자가 참여했던 모각코 목록을 조회합니다.")
     @GetMapping("/users/{userId}/mogakko/complete")
-    public ResponseEntity<List<MogakkoInfoDto>> getCompleteMogakkos(@PathVariable Long userId) {
-        List<MogakkoInfoDto> mogakkoInfoDtos = userService.getCompletedMogakkos(userId);
+    public ResponseEntity<List<MogakkoSimpleInfoResponseDto>> getCompleteMogakkos(@PathVariable Long userId) {
+        List<MogakkoSimpleInfoResponseDto> mogakkoInfoDtos = userService.getCompletedMogakkos(userId);
+
         return ResponseEntity.ok(mogakkoInfoDtos);
     }
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #130 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* 마이페이지 정보를 넘겨줄 때, 마이페이지에서 찜한 모각코 개수, 진행 중인 모각코 개수, 종료된 모각코 개수가 표시되어야 해서 그에 맞는 Count 쿼리 추가 및 서비스 로직 변경.
* 진행 중인 모각코 목록, 종료된 모각코 목록을 찜한 모각코 목록과 포맷을 같게 하여 DTO 크기를 줄임.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
count 쿼리를 만들고 나니 `MogakkoRepository`에서 비슷한 쿼리가 있는 걸 발견했네요 ㅠ 쿼리 부분이랑 코드 적으로 이상한 부분 있는지 확인만 해주시고 머지해 주세요!