### PR TITLE
129 커스텀 예외코드 적용

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -108,7 +108,7 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public Long getChatRoomIdByMogakkoId(Long mogakkoId) {
         ChatRoom chatRoom = chatRoomRepository.findByMogakkoId(mogakkoId)
-                .orElseThrow(() -> new IllegalArgumentException("Mogakko has no ChatRoom"));
+                .orElseThrow(() -> new ChatException(ChatErrorType.CHATROOM_NOT_FOUND, "해당 모각코의 채팅방이 존재하지 않습니다. : mogakkoId[" + mogakkoId + "]"));
         return chatRoom.getId();
     }
 

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
@@ -9,8 +9,9 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByIdAndDeletedAtIsNull(Long id);
 
-    @Query(value = "SELECT * FROM chat_rooms cr JOIN users_chat_room_list ucr ON cr.id = ucr.chat_room_list_id WHERE ucr.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
+    @Query(value = "SELECT * FROM chat_rooms cr JOIN chat_participants cp ON cr.id = cp.user_id WHERE cp.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
             nativeQuery = true)
     List<ChatRoom> findByParticipantsId(Long userId, Long cursorId, int pageSize);
+
     Optional<ChatRoom> findByMogakkoId(Long mogakkoId);
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByIdAndDeletedAtIsNull(Long id);
 
-    @Query(value = "SELECT * FROM chat_rooms cr JOIN chat_participants cp ON cr.id = cp.user_id WHERE cp.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
+    @Query(value = "SELECT * FROM chat_rooms cr JOIN chat_participants cp ON cr.id = cp.chat_room_id WHERE cp.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
             nativeQuery = true)
     List<ChatRoom> findByParticipantsId(Long userId, Long cursorId, int pageSize);
 

--- a/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/domain/ChatRoomRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByIdAndDeletedAtIsNull(Long id);
 
-    @Query(value = "SELECT * FROM chat_rooms cr JOIN chat_participants cp ON cr.id = cp.chat_room_id WHERE cp.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
+    @Query(value = "SELECT cr.* FROM chat_rooms cr JOIN chat_participants cp ON cr.id = cp.chat_room_id WHERE cp.user_id = :userId AND cr.id < :cursorId ORDER BY cr.id DESC limit :pageSize",
             nativeQuery = true)
     List<ChatRoom> findByParticipantsId(Long userId, Long cursorId, int pageSize);
 

--- a/src/main/java/org/prgms/locomocoserver/chat/exception/ChatErrorType.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/exception/ChatErrorType.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ChatErrorType {
-    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "Chat Room does not exist")
+    CHATROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방이 존재하지 않습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/prgms/locomocoserver/chat/exception/ChatException.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/exception/ChatException.java
@@ -10,4 +10,9 @@ public class ChatException extends RuntimeException{
         super(type.getMessage());
         this.errorType = type;
     }
+
+    public ChatException(ChatErrorType type, String message) {
+        super(message);
+        this.errorType = type;
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/global/common/dto/ErrorResponse.java
+++ b/src/main/java/org/prgms/locomocoserver/global/common/dto/ErrorResponse.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.global.common.dto;
+
+public record ErrorResponse(
+        Integer code,
+        String message
+) {
+}

--- a/src/main/java/org/prgms/locomocoserver/global/exception/AuthException.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/AuthException.java
@@ -1,0 +1,18 @@
+package org.prgms.locomocoserver.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public AuthException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/global/exception/ErrorCode.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/ErrorCode.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     ACCESSTOKEN_EXPIRED(HttpStatus.UNAUTHORIZED,1401, "Access Token Expired"),
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST,400, "Invalid Token");
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST,400, "Invalid Token"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 401, "Unauthorized"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "Internal Server Error"),
+    ;
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/org/prgms/locomocoserver/global/exception/ExpiredTokenException.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/ExpiredTokenException.java
@@ -1,7 +1,9 @@
 package org.prgms.locomocoserver.global.exception;
 
 public class ExpiredTokenException extends RuntimeException {
-    public ExpiredTokenException(String message) {
-        super(message);
+    ErrorCode errorCode;
+    public ExpiredTokenException(ErrorCode code) {
+        super(code.getMessage());
+        this.errorCode = code;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/global/exception/InvalidTokenException.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/InvalidTokenException.java
@@ -1,7 +1,9 @@
 package org.prgms.locomocoserver.global.exception;
 
 public class InvalidTokenException extends RuntimeException {
-    public InvalidTokenException(String message) {
-        super(message);
+    private ErrorCode errorCode;
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/global/filter/ExceptionHandlerFilter.java
+++ b/src/main/java/org/prgms/locomocoserver/global/filter/ExceptionHandlerFilter.java
@@ -5,18 +5,16 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.global.common.dto.ErrorResponse;
+import org.prgms.locomocoserver.global.exception.AuthException;
 import org.prgms.locomocoserver.global.exception.ErrorCode;
 import org.prgms.locomocoserver.global.exception.ExpiredTokenException;
 import org.prgms.locomocoserver.global.exception.InvalidTokenException;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
@@ -26,40 +24,39 @@ public class ExceptionHandlerFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        log.info("ExceptionHandlerFilter START");
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
 
-        try{
+        try {
             chain.doFilter(request, response);
-        }catch (ExpiredTokenException e){
-            //토큰의 유효기간 만료
-            log.info("ExceptionHandlerFilter - ExpiredTokenException: " + e.getMessage());
-            setErrorResponse(httpServletResponse, ErrorCode.ACCESSTOKEN_EXPIRED);
-        }catch (InvalidTokenException | IllegalArgumentException e){
-            //유효하지 않은 토큰
-            log.info("ExceptionHandlerFilter - InvalidTokenException: " + e.getMessage());
-            setErrorResponse(httpServletResponse, ErrorCode.INVALID_TOKEN);
+        } catch (RuntimeException e) {
+            handleException(httpServletResponse, e);
         }
     }
-    private void setErrorResponse(
-            HttpServletResponse response,
-            ErrorCode errorCode
-    ){
+
+    private void handleException(HttpServletResponse response, RuntimeException e) {
+        log.error("ExceptionHandlerFilter - Exception: " + e.getMessage());
+
+        if (e instanceof ExpiredTokenException) {
+            setErrorResponse(response, ErrorCode.ACCESSTOKEN_EXPIRED);
+        } else if (e instanceof InvalidTokenException) {
+            setErrorResponse(response, ErrorCode.INVALID_TOKEN);
+        } else if (e instanceof AuthException) {
+            setErrorResponse(response, ErrorCode.UNAUTHORIZED);
+        } else {
+            // 기타 예외 처리
+            setErrorResponse(response, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) {
         ObjectMapper objectMapper = new ObjectMapper();
         response.setStatus(errorCode.getHttpStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         ErrorResponse errorResponse = new ErrorResponse(errorCode.getCode(), errorCode.getMessage());
-        try{
-            log.info("response.getwrite : " + objectMapper.writeValueAsString(errorResponse));
+        try {
             response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
-        }catch (IOException e){
-            e.printStackTrace();
+        } catch (IOException e) {
+            log.error("Error writing error response: " + e.getMessage());
         }
-    }
-
-    @Data
-    public static class ErrorResponse{
-        private final Integer code;
-        private final String message;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
@@ -41,7 +41,7 @@ public class AuthenticationService {
         } catch (HttpClientErrorException.Unauthorized e) {
             log.error("AuthenticationService - Unauthorized Exception: " + e.getMessage());
             if (e.getMessage().contains("expire")) throw new ExpiredTokenException(ErrorCode.ACCESSTOKEN_EXPIRED);
-            throw new AuthException(ErrorCode.UNAUTHORIZED);
+            throw new AuthException(ErrorCode.UNAUTHORIZED, e.getMessage());
         } catch (HttpClientErrorException.BadRequest e) {
             log.error("AuthenticationService - BadRequest Exception: " + e.getMessage());
             throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
@@ -51,7 +51,7 @@ public class AuthenticationService {
         }
     }
 
-    public boolean authenticateKakaoUser(String accessToken) {
+    private boolean authenticateKakaoUser(String accessToken) {
         String url = "https://kapi.kakao.com/v1/user/access_token_info";
         log.info("AuthenticationService - authenticateKakaoUser");
 
@@ -66,7 +66,7 @@ public class AuthenticationService {
         return response.getStatusCode() == HttpStatus.OK;
     }
 
-    public boolean authenticateGithubUser(String accessToken) {
+    private boolean authenticateGithubUser(String accessToken) {
         String url = "https://api.github.com/applications/Iv1.8a61f9b3a7aba766/token";
         log.info("AuthenticationService - authenticateGithubUser");
 

--- a/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/AuthenticationService.java
@@ -2,8 +2,13 @@ package org.prgms.locomocoserver.user.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.global.exception.AuthException;
+import org.prgms.locomocoserver.global.exception.ErrorCode;
 import org.prgms.locomocoserver.global.exception.ExpiredTokenException;
 import org.prgms.locomocoserver.global.exception.InvalidTokenException;
+import org.prgms.locomocoserver.user.domain.enums.Provider;
+import org.prgms.locomocoserver.user.exception.UserErrorType;
+import org.prgms.locomocoserver.user.exception.UserException;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -15,53 +20,66 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class AuthenticationService {
 
+    public boolean authenticateUser(String providerValue, String accessToken) {
+        Provider provider = Provider.valueOf(providerValue.toUpperCase());
+
+        try {
+            boolean isValidToken = false;
+            switch (provider) {
+                case KAKAO:
+                    log.info("AuthenticationFilter.doFilter KAKAO authenticated called");
+                    isValidToken = authenticateKakaoUser(accessToken);
+                    break;
+                case GITHUB:
+                    log.info("AuthenticationFilter.doFilter GITHUB authenticated called");
+                    isValidToken = authenticateGithubUser(accessToken);
+                    break;
+                default:  // 잘못된 Provider
+                    throw new UserException(UserErrorType.PROVIDER_TYPE_ERROR);
+            }
+            return isValidToken;
+        } catch (HttpClientErrorException.Unauthorized e) {
+            log.error("AuthenticationService - Unauthorized Exception: " + e.getMessage());
+            if (e.getMessage().contains("expire")) throw new ExpiredTokenException(ErrorCode.ACCESSTOKEN_EXPIRED);
+            throw new AuthException(ErrorCode.UNAUTHORIZED);
+        } catch (HttpClientErrorException.BadRequest e) {
+            log.error("AuthenticationService - BadRequest Exception: " + e.getMessage());
+            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+        } catch (HttpServerErrorException e) {
+            log.error("AuthenticationService - Internal ServerError Exception: " + e.getMessage());
+            throw new AuthException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     public boolean authenticateKakaoUser(String accessToken) {
         String url = "https://kapi.kakao.com/v1/user/access_token_info";
         log.info("AuthenticationService - authenticateKakaoUser");
 
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", accessToken); // header로 넘어오는 accessToken은 Bearer 붙어있음
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", accessToken); // header로 넘어오는 accessToken은 Bearer 붙어있음
 
-            HttpEntity<String> entity = new HttpEntity<>(headers);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
 
-            return response.getStatusCode() == HttpStatus.OK;
-        } catch (HttpClientErrorException.Unauthorized e) {
-            log.info("AuthenticationService - Unauthorized Exception: " + e.getMessage());
-            throw new ExpiredTokenException("Kakao access token expired");
-        } catch (HttpClientErrorException.BadRequest e) {
-            log.info("AuthenticationService - BadRequest Exception: " + e.getMessage());
-            throw new InvalidTokenException("Invalid Kakao access token");
-        } catch (HttpServerErrorException e) {
-            log.info("AuthenticationService - Internal ServerError Exception: " + e.getMessage());
-            throw new RuntimeException("Error occurred during Kakao authentication", e);
-        }
+        return response.getStatusCode() == HttpStatus.OK;
     }
 
     public boolean authenticateGithubUser(String accessToken) {
         String url = "https://api.github.com/applications/Iv1.8a61f9b3a7aba766/token";
         log.info("AuthenticationService - authenticateGithubUser");
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", accessToken);
-            headers.set("Accept", "application/vnd.github+json");
-            headers.set("X-GitHub-Api-Version", "2022-11-28");
 
-            HttpEntity<String> entity = new HttpEntity<>(headers);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", accessToken);
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("X-GitHub-Api-Version", "2022-11-28");
 
-            RestTemplate restTemplate = new RestTemplate();
-            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
 
-            return response.getStatusCode() == HttpStatus.OK;
-        } catch (HttpClientErrorException.Unauthorized e) {
-            throw new ExpiredTokenException("GitHub access token expired");
-        } catch (HttpClientErrorException.BadRequest e) {
-            throw new InvalidTokenException("Invalid GitHub access token");
-        } catch (HttpServerErrorException e) {
-            throw new RuntimeException("Error occurred during GitHub authentication", e);
-        }
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+
+        return response.getStatusCode() == HttpStatus.OK;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/exception/UserErrorType.java
+++ b/src/main/java/org/prgms/locomocoserver/user/exception/UserErrorType.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UserErrorType {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다."),
-    PROVIDER_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "해당 provider가 존재하지 않습니다.")
+    PROVIDER_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "해당 provider가 존재하지 않습니다."),
+    BIRTH_TYPE_ERROR(HttpStatus.BAD_REQUEST, "생년월일이 형식에 맞지 않습니다."),
+    EMAIL_TYPE_ERROR(HttpStatus.BAD_REQUEST, "이메일이 형식에 맞지 않습니다."),
+    TEMPERATURE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "온도는 0도 이상 100도 이하의 값이어야 합니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/prgms/locomocoserver/user/vo/BirthVo.java
+++ b/src/main/java/org/prgms/locomocoserver/user/vo/BirthVo.java
@@ -1,6 +1,8 @@
 package org.prgms.locomocoserver.user.vo;
 
 import lombok.Getter;
+import org.prgms.locomocoserver.user.exception.UserErrorType;
+import org.prgms.locomocoserver.user.exception.UserException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,7 +15,7 @@ public class BirthVo {
 
     public BirthVo(LocalDate birth) {
         if (!isValidBirth(birth)) {
-            throw new IllegalArgumentException("Invalid birth");
+            throw new UserException(UserErrorType.BIRTH_TYPE_ERROR);
         }
         this.birth = birth;
     }

--- a/src/main/java/org/prgms/locomocoserver/user/vo/EmailVo.java
+++ b/src/main/java/org/prgms/locomocoserver/user/vo/EmailVo.java
@@ -1,6 +1,8 @@
 package org.prgms.locomocoserver.user.vo;
 
 import lombok.Getter;
+import org.prgms.locomocoserver.user.exception.UserErrorType;
+import org.prgms.locomocoserver.user.exception.UserException;
 
 @Getter
 public class EmailVo {
@@ -10,7 +12,7 @@ public class EmailVo {
 
     public EmailVo(String email) {
         if (!isValidEmail(email)) {
-            throw new IllegalArgumentException("Invalid email");
+            throw new UserException(UserErrorType.EMAIL_TYPE_ERROR);
         }
         this.email = email;
     }

--- a/src/main/java/org/prgms/locomocoserver/user/vo/TemperatureVo.java
+++ b/src/main/java/org/prgms/locomocoserver/user/vo/TemperatureVo.java
@@ -1,6 +1,8 @@
 package org.prgms.locomocoserver.user.vo;
 
 import lombok.Getter;
+import org.prgms.locomocoserver.user.exception.UserErrorType;
+import org.prgms.locomocoserver.user.exception.UserException;
 
 @Getter
 public class TemperatureVo {
@@ -8,7 +10,7 @@ public class TemperatureVo {
 
     public TemperatureVo(double temperature) {
         if (!isValidTemperature(temperature)) {
-            throw new IllegalArgumentException("Invalid temperature");
+            throw new UserException(UserErrorType.TEMPERATURE_TYPE_ERROR);
         }
         this.temperature = temperature;
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #129 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- FE와 만료된 토큰에 대한 커스텀 에러코드(1401)가 필요함을 확인 후 filter에서 처리하는 [ErrorResponse](src/main/java/org/prgms/locomocoserver/global/common/dto/ErrorResponse.java) 및 [ErrorCode](src/main/java/org/prgms/locomocoserver/global/exception/ErrorCode.java) 생성
- 커스텀 예외 적용되지 않은 부분에 대한 추가
- try-catch 중복 코드 정리

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
filter 부분에서 try-catch가 지저분하게 중복되었던 부분 조금 수정했습니다..! 프론트에서 만료된 토큰에 대해서는 401 외의 구분이 필요하다고 하여 논의해 코드 지정하고 커스텀 예외코드를 적용하게 되었습니다. 코드 읽다가 예외처리 빠진 부분이나 바뀌었으면 하는 부분 있으면 코멘트 달아주세요~~
