### PR TITLE
Fix 151 유저 생성 시 자동으로 device key 테이블에도 추가

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
@@ -19,6 +19,8 @@ import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantReposito
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
+import org.prgms.locomocoserver.user.domain.DeviceKey;
+import org.prgms.locomocoserver.user.domain.DeviceKeyRepository;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.prgms.locomocoserver.user.domain.enums.Gender;
@@ -45,6 +47,7 @@ public class UserService {
     private final MogakkoLikeRepository mogakkoLikeRepository;
     private final ParticipantRepository participantRepository;
     private final TagRepository tagRepository;
+    private final DeviceKeyRepository deviceKeyRepository;
     private final ImageService imageService;
 
     @Transactional
@@ -70,6 +73,8 @@ public class UserService {
         Tag jobTag = tagRepository.findById(requestDto.jobId()).orElseThrow(RuntimeException::new); // TODO: 태그 예외 반환
         user.setInitInfo(requestDto.nickname(), requestDto.birth(),
                 Gender.valueOf(requestDto.gender().toUpperCase()), jobTag);
+        deviceKeyRepository.save(DeviceKey.builder().user(user).build());
+
         if (multipartFile != null) uploadProfileImage(userId, multipartFile);
 
         return UserInfoDto.of(user);

--- a/src/main/java/org/prgms/locomocoserver/user/domain/DeviceKey.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/DeviceKey.java
@@ -1,0 +1,47 @@
+package org.prgms.locomocoserver.user.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "device_key")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceKey {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "phone")
+    private String phone;
+
+    @Column(name = "pad")
+    private String pad;
+
+    @Column(name = "desktop")
+    private String desktop;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public DeviceKey(String phone, String pad, String desktop, User user) {
+        this.phone = phone;
+        this.pad = pad;
+        this.desktop = desktop;
+        this.user = user;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/domain/DeviceKeyRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/DeviceKeyRepository.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DeviceKeyRepository extends JpaRepository<DeviceKey, Long> {
+
+}

--- a/src/test/java/org/prgms/locomocoserver/user/application/UserServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/UserServiceTest.java
@@ -1,0 +1,87 @@
+package org.prgms.locomocoserver.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.categories.domain.Category;
+import org.prgms.locomocoserver.categories.domain.CategoryInputType;
+import org.prgms.locomocoserver.categories.domain.CategoryRepository;
+import org.prgms.locomocoserver.categories.domain.CategoryType;
+import org.prgms.locomocoserver.tags.domain.Tag;
+import org.prgms.locomocoserver.tags.domain.TagRepository;
+import org.prgms.locomocoserver.user.domain.DeviceKeyRepository;
+import org.prgms.locomocoserver.user.domain.User;
+import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.prgms.locomocoserver.user.domain.enums.Gender;
+import org.prgms.locomocoserver.user.dto.request.UserInitInfoRequestDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+class UserServiceTest {
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private DeviceKeyRepository deviceKeyRepository;
+    @Autowired
+    private UserRepository userRepository;
+
+    private Tag engineer;
+
+    @BeforeEach
+    void setUp() {
+        Category jobCategory = Category.builder().categoryType(CategoryType.USER)
+            .categoryInputType(CategoryInputType.RADIOGROUP).name("직업").build();
+        categoryRepository.save(jobCategory);
+
+        engineer = Tag.builder().name("현직자").build();
+        tagRepository.saveAll(List.of(engineer));
+    }
+
+    @AfterEach
+    void tearDown() {
+        tagRepository.deleteAll();
+        categoryRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("초기 회원가입 정보 저장이 성공하고 디바이스 키도 제대로 저장된다")
+    @Transactional
+    void success_insert_init_user_info_and_device_key() {
+        // given
+        String initEmail = "namaewa@gmail.com";
+        User user = User.builder().email(initEmail).gender(
+                Gender.FEMALE).temperature(36.5).provider("kakao").build();
+        userRepository.save(user);
+
+        // when
+        String initName = "kimino";
+        LocalDate initBirth = LocalDate.of(2017, 1, 4);
+        userService.insertInitInfo(user.getId(),
+            new UserInitInfoRequestDto(initName, initBirth,
+                Gender.FEMALE.name(), engineer.getId()), null);
+
+        // then
+        Optional<User> userOptional = userRepository.findById(user.getId());
+        assertThat(userOptional).isPresent();
+
+        User foundUser = userOptional.get();
+        assertThat(foundUser.getNickname()).isEqualTo(initName);
+        assertThat(foundUser.getBirth()).isEqualTo(initBirth);
+        assertThat(foundUser.getEmail()).isEqualTo(initEmail);
+        assertThat(foundUser.getJobTag().getId()).isEqualTo(engineer.getId());
+
+        assertThat(deviceKeyRepository.findAll()).hasSize(1);
+    }
+}


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #151 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
유저 회원가입 시 자동으로 그 유저 관련 device key 레코드가 삽입됩니다. 이 device key는 이후 프론트엔드에서 관리합니다.
* `DeviceKey` 엔티티 생성
* `UserService`의 `initUserInfo()` 메서드에서 device key 레코드 삽입 로직 추가

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
간단 로직입니다. 훑어만 봐도 좋을 것 같아요~