### PR TITLE
fix #162: 데드 라인은 모각코 종료 시간보다 앞에 있기만 하도록 수정

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -160,7 +160,7 @@ public class Mogakko extends BaseEntity {
         if (this.content.length() > MAX_CONTENT_LEN) {
             throw new RuntimeException("내용 최대 길이를 초과했습니다!");
         }
-        if (this.startTime.isAfter(this.endTime) || this.deadline.isAfter(this.endTime) || this.startTime.isAfter(this.deadline)) {
+        if (this.startTime.isAfter(this.endTime) || this.deadline.isAfter(this.endTime)) {
             throw new RuntimeException("날짜 설정이 잘못되었습니다!");
         }
         if (this.maxParticipants < 0 || this.maxParticipants > DEFAULT_MAX_PARTICIPANTS) {

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoTest.java
@@ -51,20 +51,16 @@ class MogakkoTest {
     }
 
     @Test
-    @DisplayName("데드 라인이 시작 시간과 끝 시간 사이에 있지 않은 모각코는 생성할 수 없다")
+    @DisplayName("데드 라인이 끝 시간 뒤에 존재하는 모각코는 생성할 수 없다")
     void fail_create_Mogakko_given_deadline_is_not_between_endTime_and_startTime() {
         // given
         LocalDateTime startTime = LocalDateTime.now();
         LocalDateTime endTime = startTime.plusHours(2);
-        LocalDateTime deadline1 = startTime.plusHours(3);
-        LocalDateTime deadline2 = startTime.minusHours(1);
+        LocalDateTime deadline = startTime.plusHours(3);
 
         // when then
         assertThrows(RuntimeException.class, () -> Mogakko.builder().title("title").content("content").views(1L).likeCount(0) // TODO: 모각코 예외 반환
-            .startTime(startTime).deadline(deadline1).endTime(endTime)
-            .maxParticipants(10).creator(testUser).build());
-        assertThrows(RuntimeException.class, () -> Mogakko.builder().title("title").content("content").views(1L).likeCount(0) // TODO: 모각코 예외 반환
-            .startTime(startTime).deadline(deadline2).endTime(endTime)
+            .startTime(startTime).deadline(deadline).endTime(endTime)
             .maxParticipants(10).creator(testUser).build());
     }
 


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #162 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
validate 수정

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
데드 라인이 시작 시간 뒤에 있어야 할 것 같았는데 알고 보니 아니었습니다. 그냥 종료 시간보다 앞에만 있으면 되네요. 수정했습니다!
