### PR TITLE
Refactor 174 필터링 최적화

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package org.prgms.locomocoserver.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.image.exception.ImageException;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.review.exception.ReviewException;
 import org.prgms.locomocoserver.user.exception.UserException;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(UserException.class)
@@ -23,5 +26,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ReviewException.class)
     public ResponseEntity<Object> handleReviewException(ReviewException ex) {
         return ResponseEntity.status(ex.getErrorType().getStatus()).body(ex.getErrorType().getMessage());
+    }
+
+    @ExceptionHandler(MogakkoException.class)
+    public ResponseEntity<?> handleMogakkoException(MogakkoException ex) {
+        log.error(ex.getErrorCode().getMessage());
+        return ResponseEntity.status(ex.getErrorCode().getHttpStatus()).body(ex.getErrorCode().getMessage());
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -14,7 +14,8 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
 
     @Query(value = "SELECT m.* FROM mogakko m "
-        + "JOIN locations l ON (m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND l.mogakko_id = m.id AND l.city LIKE :city%) "
+        + "JOIN locations l ON (m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND l.mogakko_id = m.id) "
+        + "WHERE MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
     List<Mogakko> findAllByCity(Long cursor, String city, int pageSize, LocalDateTime now);
@@ -22,8 +23,8 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query(value = "SELECT m.* "
         + "FROM mogakko_tags mt "
         + "INNER JOIN mogakko m ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.id = mt.mogakko_id "
-        + "INNER JOIN locations l ON l.mogakko_id = m.id AND l.city LIKE :city% "
-        + "WHERE mt.tag_id IN :tagIds "
+        + "INNER JOIN locations l ON l.mogakko_id = m.id "
+        + "WHERE mt.tag_id IN :tagIds AND MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) "
         + "GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
@@ -33,7 +34,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "INNER JOIN users u ON m.id < :cursor AND m.deleted_at IS NULL AND m.deadline > :now AND m.creator_id = u.id "
         + "INNER JOIN locations l ON l.mogakko_id = m.id "
         + "INNER JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
-        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
+        + "WHERE MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE) OR u.nickname LIKE :searchVal% OR MATCH(l.city) AGAINST(:searchVal IN BOOLEAN MODE) "
         + "GROUP BY m.id HAVING count(m.id) = :tagSize "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
@@ -42,7 +43,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
         + "INNER JOIN users u ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.creator_id = u.id "
         + "INNER JOIN locations l ON l.mogakko_id = m.id "
-        + "WHERE (m.title LIKE %:searchVal% OR m.content LIKE %:searchVal% OR u.nickname LIKE %:searchVal% OR l.city LIKE %:searchVal%) "
+        + "WHERE MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE) OR u.nickname LIKE :searchVal% OR MATCH(l.city) AGAINST(:searchVal IN BOOLEAN MODE) "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
     List<Mogakko> findAllByFilter(Long cursor, String searchVal, int pageSize, LocalDateTime now);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -40,7 +40,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "LIMIT :pageSize", nativeQuery = true)
     List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize, int pageSize, LocalDateTime now);
 
-    @Query(value = "SELECT DISTINCT m.* FROM mogakko m "
+    @Query(value = "SELECT m.* FROM mogakko m "
         + "INNER JOIN users u ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.creator_id = u.id "
         + "INNER JOIN locations l ON l.mogakko_id = m.id "
         + "WHERE MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE) OR u.nickname LIKE :searchVal% OR MATCH(l.city) AGAINST(:searchVal IN BOOLEAN MODE) "

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorCode.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum MogakkoErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, 700, "해당 모각코를 찾을 수 없습니다."),
     PROCESS_FORBIDDEN(HttpStatus.FORBIDDEN, 701, "해당 모각코 작성자만 처리할 수 있습니다."),
-    CREATE_FORBIDDEN(HttpStatus.BAD_REQUEST, 702, "다음 이유로 생성이 불가능합니다. - ");
+    CREATE_FORBIDDEN(HttpStatus.BAD_REQUEST, 702, "다음 이유로 생성이 불가능합니다. - "),
+    TOO_LITTLE_INPUT(HttpStatus.BAD_REQUEST, 703, "입력 값이 최소한 다음 길이보다 길어야 합니다 - ");
 
     private HttpStatus httpStatus;
     private int code;

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -17,6 +17,8 @@ import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoLikeDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +46,10 @@ public class MogakkoController {
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "100") Integer pageSize,
             @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
         searchVal = searchVal.strip();
+
+        if (searchVal.length() == 1) {
+            throw new MogakkoException(MogakkoErrorCode.TOO_LITTLE_INPUT.appendMessage("2"));
+        }
 
         List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags,
                 cursor, searchVal, searchType, pageSize);


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #174 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* 기존의 LIKE '%문자열%' 문을 없애고 MySQL의 Fulltext index를 이용해 부분 문자열에 대한 인덱스를 전부 생성하여 검색 속도를 높이도록 쿼리를 수정했습니다.
* 이에 따라 1글자 검색은 어떤 결과도 반환할 수 없습니다. 이는 n-gram parser 방식을 이용했기 때문인데, 부분 문자열 인덱스가 최소 2글자씩 생성되기에 1글자로는 인덱스를 찾을 수 없기 때문입니다.
* 그래서 1글자 검색에 대한 예외를 추가 및 적용했습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
쿼리 쪽 확인만 부탁드려요. Fulltext Index 기반으로 잘못된 부분이 있나 확인도 부탁드립니다. 아래는 관련 레퍼런스들입니다.

- https://scarelt.tistory.com/10
- https://velog.io/@sjnqkqh/MYSQL-FULLTEXT-Index-%EC%82%AC%EC%9A%A9%EA%B8%B0
- https://gngsn.tistory.com/162