### PR TITLE
173 redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:junit-jupiter'
     runtimeOnly 'com.h2database:h2'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // AWS S3
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.1.RELEASE'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/prgms/locomocoserver/global/config/RedisConfig.java
+++ b/src/main/java/org/prgms/locomocoserver/global/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -19,9 +20,16 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory(){
-        return new LettuceConnectionFactory(redisHost, redisPort);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(redisPort);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean

--- a/src/main/java/org/prgms/locomocoserver/global/config/RedisConfig.java
+++ b/src/main/java/org/prgms/locomocoserver/global/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package org.prgms.locomocoserver.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        // StringRedisSerializer 직렬화 방법 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());    // 문자열 key 저장
+        redisTemplate.setValueSerializer(new StringRedisSerializer());  // 문자열 value 저장
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
@@ -1,0 +1,28 @@
+package org.prgms.locomocoserver.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.user.domain.RefreshTokenRepository;
+import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void saveTokenInfo(TokenResponseDto tokenResponseDto) {
+        refreshTokenRepository.save(tokenResponseDto.toRefreshTokenEntity());
+    }
+
+    @Transactional
+    public void removeRefreshToken(String accessToken) {
+
+    }
+
+    public void updateRefreshToken(String accessToken) {
+
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
@@ -1,28 +1,58 @@
 package org.prgms.locomocoserver.user.application;
 
 import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.user.domain.RefreshToken;
 import org.prgms.locomocoserver.user.domain.RefreshTokenRepository;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
+    @Value("${oauth.kakao.REST_API_KEY}")
+    private String kakao_api_key;
 
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public void saveTokenInfo(TokenResponseDto tokenResponseDto) {
-        refreshTokenRepository.save(tokenResponseDto.toRefreshTokenEntity());
+    public String saveTokenInfo(TokenResponseDto tokenResponseDto) {
+        RefreshToken refreshToken = refreshTokenRepository.save(tokenResponseDto.toRefreshTokenEntity());
+        return refreshToken.getAccessToken();
     }
 
     @Transactional
     public void removeRefreshToken(String accessToken) {
-
+        refreshTokenRepository.deleteByAccessToken(accessToken);
     }
 
-    public void updateRefreshToken(String accessToken) {
+    @Transactional
+    public TokenResponseDto updateRefreshToken(String refreshToken) {
+        TokenResponseDto tokenResponseDto = refreshAccessToken(refreshToken);
+        return tokenResponseDto;
+    }
 
+    private TokenResponseDto refreshAccessToken(String refreshToken) {
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", kakao_api_key);
+        params.add("refresh_token", refreshToken);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<TokenResponseDto> response = restTemplate.exchange(url, HttpMethod.POST, requestEntity, TokenResponseDto.class);
+
+        return response.getBody();
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
@@ -1,0 +1,30 @@
+package org.prgms.locomocoserver.user.domain;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@RedisHash(value = "refresh_token", timeToLive = 60*60*24*3)
+public class RefreshToken {
+
+    @Id
+    private String id;
+
+    private String refreshToken;
+    private long refreshTokenExpiresIn;
+
+    @Indexed
+    private String accessToken;
+    private long accessTokenExpiresIn;
+
+    @Builder
+    public RefreshToken(String refreshToken, long refreshTokenExpiresIn, String accessToken, long accessTokenExpiresIn) {
+        this.refreshToken = refreshToken;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+        this.accessToken = accessToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
@@ -13,18 +13,14 @@ public class RefreshToken {
     @Id
     private String id;
 
-    private String refreshToken;
-    private long refreshTokenExpiresIn;
-
     @Indexed
     private String accessToken;
-    private long accessTokenExpiresIn;
+
+    private String refreshToken;
 
     @Builder
-    public RefreshToken(String refreshToken, long refreshTokenExpiresIn, String accessToken, long accessTokenExpiresIn) {
-        this.refreshToken = refreshToken;
-        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    public RefreshToken(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
-        this.accessTokenExpiresIn = accessTokenExpiresIn;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
@@ -6,5 +6,4 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByAccessToken(String accessToken);
-    void deleteByAccessToken(String refreshToken);
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package org.prgms.locomocoserver.user.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByAccessToken(String accessToken);
+}

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshTokenRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByAccessToken(String accessToken);
+    void deleteByAccessToken(String refreshToken);
 }

--- a/src/main/java/org/prgms/locomocoserver/user/dto/response/TokenResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/response/TokenResponseDto.java
@@ -3,6 +3,7 @@ package org.prgms.locomocoserver.user.dto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.prgms.locomocoserver.user.domain.RefreshToken;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TokenResponseDto(
@@ -22,4 +23,12 @@ public record TokenResponseDto(
         @Schema(description = "리프레시 토큰 만료", example = "28000")
         int refreshTokenExpiresIn
 ) {
+        public RefreshToken toRefreshTokenEntity() {
+                return RefreshToken.builder()
+                        .refreshToken(refreshToken)
+                        .refreshTokenExpiresIn(refreshTokenExpiresIn)
+                        .accessTokenExpiresIn(expiresIn)
+                        .accessToken(accessToken)
+                        .build();
+        }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/dto/response/TokenResponseDto.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/response/TokenResponseDto.java
@@ -26,8 +26,6 @@ public record TokenResponseDto(
         public RefreshToken toRefreshTokenEntity() {
                 return RefreshToken.builder()
                         .refreshToken(refreshToken)
-                        .refreshTokenExpiresIn(refreshTokenExpiresIn)
-                        .accessTokenExpiresIn(expiresIn)
                         .accessToken(accessToken)
                         .build();
         }

--- a/src/main/java/org/prgms/locomocoserver/user/exception/UserErrorType.java
+++ b/src/main/java/org/prgms/locomocoserver/user/exception/UserErrorType.java
@@ -9,7 +9,9 @@ public enum UserErrorType {
     PROVIDER_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "해당 provider가 존재하지 않습니다."),
     BIRTH_TYPE_ERROR(HttpStatus.BAD_REQUEST, "생년월일이 형식에 맞지 않습니다."),
     EMAIL_TYPE_ERROR(HttpStatus.BAD_REQUEST, "이메일이 형식에 맞지 않습니다."),
-    TEMPERATURE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "온도는 0도 이상 100도 이하의 값이어야 합니다.")
+    TEMPERATURE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "온도는 0도 이상 100도 이하의 값이어야 합니다."),
+    ACCESSTOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 엑세스 토큰이 존재하지 않습니다."),
+    REFRESHTOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰이 만료되었습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
@@ -61,6 +61,7 @@ public class KakaoController {
         log.info("KakaoController.getKakaoLoginCallback after loadUserInfo : " + kakaoUserInfoResponseDto.getEmail());
 
         UserLoginResponse userLoginResponse = userService.saveOrUpdate(kakaoUserInfoResponseDto, tokenResponseDto);
+        refreshTokenService.saveTokenInfo(tokenResponseDto);
 
         log.info("KakaoController.getKakaoLoginCallback after saveOrUpdate : " + userLoginResponse.isNewUser());
 

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.user.application.RefreshTokenService;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.dto.kakao.KakaoUserInfoResponseDto;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
@@ -29,6 +30,7 @@ import java.io.IOException;
 public class KakaoController {
 
     private final UserService userService;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${oauth.kakao.REST_API_KEY}")
     private String kakao_api_key;
@@ -63,6 +65,13 @@ public class KakaoController {
         log.info("KakaoController.getKakaoLoginCallback after saveOrUpdate : " + userLoginResponse.isNewUser());
 
         return ResponseEntity.ok(userLoginResponse);
+    }
+
+    @Operation(summary = "accessToken 재발급", description = "accessToken이 만료되어 재발급합니다.")
+    @GetMapping("/users/refresh/kakao")
+    public ResponseEntity<TokenResponseDto> refreshToken(@RequestHeader String accessToken) {
+        TokenResponseDto tokenResponseDto = refreshTokenService.updateAccessToken(accessToken);
+        return ResponseEntity.ok(tokenResponseDto);
     }
 
     @Operation(summary = "로그인된 사용자 정보 조회", description = "access token으로 사용자 정보를 조회합니다.")

--- a/src/test/java/org/prgms/locomocoserver/global/AbstractRedisContainerBaseTest.java
+++ b/src/test/java/org/prgms/locomocoserver/global/AbstractRedisContainerBaseTest.java
@@ -1,11 +1,17 @@
 package org.prgms.locomocoserver.global;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 public abstract class AbstractRedisContainerBaseTest {
+    static final Logger log = LoggerFactory.getLogger(AbstractRedisContainerBaseTest.class);
 
     static final String REDIS_IMAGE = "redis:7-alpine";
     static final int REDIS_PORT = 6379;
@@ -15,10 +21,17 @@ public abstract class AbstractRedisContainerBaseTest {
     static {
         REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
             .withExposedPorts(REDIS_PORT)
+            .waitingFor(Wait.forListeningPort())
             .withReuse(true);
         REDIS_CONTAINER.start();
+    }
 
-        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
-        System.setProperty("spring.data.redis.port", String.valueOf(REDIS_CONTAINER.getMappedPort(REDIS_PORT)));
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry registry){
+        log.info("spring.data.redis.host: {}, spring.data.redis.port: {}", REDIS_CONTAINER.getHost(),
+            REDIS_CONTAINER.getMappedPort(REDIS_PORT));
+
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> String.valueOf(REDIS_CONTAINER.getMappedPort(REDIS_PORT)));
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/global/AbstractRedisContainerBaseTest.java
+++ b/src/test/java/org/prgms/locomocoserver/global/AbstractRedisContainerBaseTest.java
@@ -1,0 +1,24 @@
+package org.prgms.locomocoserver.global;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class AbstractRedisContainerBaseTest {
+
+    static final String REDIS_IMAGE = "redis:7-alpine";
+    static final int REDIS_PORT = 6379;
+    @Container
+    public static final GenericContainer<?> REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
+            .withExposedPorts(REDIS_PORT)
+            .withReuse(true);
+        REDIS_CONTAINER.start();
+
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(REDIS_CONTAINER.getMappedPort(REDIS_PORT)));
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
@@ -1,0 +1,52 @@
+package org.prgms.locomocoserver.user.application;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.user.domain.RefreshTokenRepository;
+import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class RefreshTokenServiceTest {
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+        refreshTokenRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("accessToken을 저장할 수 있다.")
+    void saveTokenInfo() {
+        // given
+        TokenResponseDto tokenResponseDto = new TokenResponseDto("accessToken", "bearer", "refreshToken", 3800, 14000);
+
+        // when
+        String accessToken = refreshTokenService.saveTokenInfo(tokenResponseDto);
+
+        // then
+        assertEquals("accessToken", accessToken);
+    }
+
+    @Test
+    void removeRefreshToken() {
+    }
+
+    @Test
+    void updateRefreshToken() {
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
@@ -1,7 +1,5 @@
 package org.prgms.locomocoserver.user.application;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +9,9 @@ import org.prgms.locomocoserver.user.domain.RefreshTokenRepository;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
@@ -20,6 +21,9 @@ class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
 
     @Autowired
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
 
     @BeforeEach
     void setUp() {
@@ -31,7 +35,7 @@ class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
     }
 
     @Test
-    @DisplayName("accessToken을 저장할 수 있다.")
+    @DisplayName("refreshToken을 저장할 수 있다.")
     void saveTokenInfo() {
         // given
         TokenResponseDto tokenResponseDto = new TokenResponseDto("accessToken", "bearer", "refreshToken", 3800, 14000);
@@ -44,10 +48,16 @@ class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
     }
 
     @Test
+    @DisplayName("refreshToken을 지울 수 있다.")
     void removeRefreshToken() {
-    }
+        // given
+        TokenResponseDto tokenResponseDto = new TokenResponseDto("accessToken", "bearer", "refreshToken", 3800, 14000);
+        String accessToken = refreshTokenService.saveTokenInfo(tokenResponseDto);
 
-    @Test
-    void updateRefreshToken() {
+        // when
+        refreshTokenService.removeAccessToken(accessToken);
+
+        // then
+        assertEquals(0, refreshTokenRepository.count());
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
@@ -1,18 +1,19 @@
 package org.prgms.locomocoserver.user.application;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.global.AbstractRedisContainerBaseTest;
 import org.prgms.locomocoserver.user.domain.RefreshTokenRepository;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
-class RefreshTokenServiceTest {
+class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
 
     @Autowired
     private RefreshTokenService refreshTokenService;


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #173 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- redis 설정 및 적용
- 로그인 시 key : accessToken, value: refreshToken redis 저장
- 프론트 토큰 만료 에러 시 accessToken 재발급 요청 api 구성
- redis 저장, 삭제 테스트 코드 작성

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
- 로그아웃 시에 프론트에서 카카오 api를 직접 불러 accessToken을 만료시키고 있는데, 그때 redis에서도 해당 accessToken을 삭제하는 api가 추가적으로 구현 필요합니다 : 프론트와 방식 협의 후에 추가할 예정입니다..!
- 현재 카카오에서 공식적으로 넘겨주는 refreshToken의 만료기간은 2개월인데, redis에서는 일단 보안상 3일로 지정했습니다. 관련해서 의견 있으면 말해주세요 !
- AWS Redis 접근이 잘 되는지 확인이 필요할 것 같아서 다른 세세한 구현은 미뤄두고 일단 기본적으로 로그인시에 저장, 만료시에 업데이트 기능만 구현하였습니다..! 그래도 추가적인 처리 필요할 것 같은 부분 코멘트 많이 남겨주세요..!!
- yml 파일 업데이트 되었습니다 !
