### PR TITLE
Feature 178 에러 발생 슬랙 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Slack 연동
+    implementation 'com.slack.api:slack-api-client:1.39.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/prgms/locomocoserver/global/common/SlackAlertService.java
+++ b/src/main/java/org/prgms/locomocoserver/global/common/SlackAlertService.java
@@ -1,0 +1,60 @@
+package org.prgms.locomocoserver.global.common;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.global.common.dto.SlackErrorAlertDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class SlackAlertService {
+    private static final String RED = "#ff0000";
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${webhook.slack.url}")
+    private String webhookUrl;
+
+    public void sendAlertLog(SlackErrorAlertDto dto) {
+        try {
+            slackClient.send(webhookUrl, payload(p -> p
+                .text("서버 에러 발생! 백엔드 측의 빠른 확인 요망")
+                // attachment는 list 형태여야 합니다.
+                .attachments(
+                    List.of(generateErrorAttachment(dto))
+                )
+            ));
+        } catch (IOException slackError) {
+            log.info("Slack 통신과의 예외 발생");
+        }
+    }
+
+    // attachment 생성 메서드
+    private Attachment generateErrorAttachment(SlackErrorAlertDto dto) {
+        return Attachment.builder()
+            .color(RED)
+            .title("에러 로그")
+            .fields(List.of(
+                    generateSlackField("Request URL", dto.requestUrl() + " " + dto.httpMethod()),
+                    generateSlackField("Error Message", dto.errorMessage())
+                )
+            )
+            .build();
+    }
+
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+            .title(title)
+            .value(value)
+            .valueShortEnough(false)
+            .build();
+    }
+
+}

--- a/src/main/java/org/prgms/locomocoserver/global/common/dto/SlackErrorAlertDto.java
+++ b/src/main/java/org/prgms/locomocoserver/global/common/dto/SlackErrorAlertDto.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.global.common.dto;
+
+public record SlackErrorAlertDto(String requestUrl,
+                                 String httpMethod,
+                                 String errorMessage) {
+
+}

--- a/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package org.prgms.locomocoserver.global.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.global.common.SlackAlertService;
+import org.prgms.locomocoserver.global.common.dto.SlackErrorAlertDto;
 import org.prgms.locomocoserver.image.exception.ImageException;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.review.exception.ReviewException;
@@ -9,28 +13,51 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
 @Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+    private final SlackAlertService slackAlertService;
 
     @ExceptionHandler(UserException.class)
-    public ResponseEntity<Object> handleUserException(UserException ex) {
+    public ResponseEntity<Object> handleUserException(UserException ex, HttpServletRequest request) {
+        slackAlertService.sendAlertLog(
+            new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
+                ex.getErrorType().getMessage()));
         return ResponseEntity.status(ex.getErrorType().getStatus()).body(ex.getErrorType().getMessage());
     }
 
     @ExceptionHandler(ImageException.class)
-    public ResponseEntity<Object> handleImageException(ImageException ex) {
+    public ResponseEntity<Object> handleImageException(ImageException ex, HttpServletRequest request) {
+        slackAlertService.sendAlertLog(
+            new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
+                ex.getErrorType().getMessage()));
         return ResponseEntity.status(ex.getErrorType().getStatus()).body(ex.getErrorType().getMessage());
     }
 
     @ExceptionHandler(ReviewException.class)
-    public ResponseEntity<Object> handleReviewException(ReviewException ex) {
+    public ResponseEntity<Object> handleReviewException(ReviewException ex, HttpServletRequest request) {
+        slackAlertService.sendAlertLog(
+            new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
+                ex.getErrorType().getMessage()));
         return ResponseEntity.status(ex.getErrorType().getStatus()).body(ex.getErrorType().getMessage());
     }
 
     @ExceptionHandler(MogakkoException.class)
-    public ResponseEntity<?> handleMogakkoException(MogakkoException ex) {
-        log.error(ex.getErrorCode().getMessage());
-        return ResponseEntity.status(ex.getErrorCode().getHttpStatus()).body(ex.getErrorCode().getMessage());
+    public ResponseEntity<?> handleMogakkoException(MogakkoException ex, HttpServletRequest request) {
+        slackAlertService.sendAlertLog(
+            new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
+                ex.getErrorType().getMessage()));
+        log.error(ex.getErrorType().getMessage());
+        return ResponseEntity.status(ex.getErrorType().getHttpStatus()).body(ex.getErrorType().getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleUnknownException(Exception ex, HttpServletRequest request) {
+        slackAlertService.sendAlertLog(
+            new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
+                ex.getMessage()));
+        log.error("알 수 없는 에러 발생: {}", ex.getMessage());
+        return ResponseEntity.status(500).body(ex.getMessage());
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -10,7 +10,7 @@ import org.prgms.locomocoserver.inquiries.dto.response.InquiryResponseDto;
 import org.prgms.locomocoserver.inquiries.dto.response.InquiryUpdateResponseDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
@@ -30,7 +30,7 @@ public class InquiryService {
         User user = userRepository.findById(requestDto.userId())
             .orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND)); // TODO: 유저 예외 반환
         Mogakko mogakko = mogakkoRepository.findById(requestDto.mogakkoId())
-            .orElseThrow(() -> new MogakkoException(MogakkoErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new MogakkoException(MogakkoErrorType.NOT_FOUND));
 
         Inquiry inquiry = Inquiry.builder().mogakko(mogakko).user(user).content(requestDto.content())
             .build();

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -11,7 +11,7 @@ import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
 import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.domain.User;
@@ -39,7 +39,7 @@ public class MogakkoParticipationService {
 
     public void participate(Long mogakkoId, ParticipationRequestDto requestDto) {
         Mogakko mogakko = mogakkoRepository.findByIdAndDeletedAtIsNull(mogakkoId)
-            .orElseThrow(() -> new MogakkoException(MogakkoErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new MogakkoException(MogakkoErrorType.NOT_FOUND));
         User user = userService.getById(requestDto.userId());
 
         validateIfDeadlineIsPast(mogakko);
@@ -53,7 +53,7 @@ public class MogakkoParticipationService {
 
     public void cancel(Long mogakkoId, Long userId) {
         Mogakko mogakko = mogakkoRepository.findByIdAndDeletedAtIsNull(mogakkoId)
-            .orElseThrow(() -> new MogakkoException(MogakkoErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new MogakkoException(MogakkoErrorType.NOT_FOUND));
 
         validateIfEndTimeIsPast(mogakko);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -26,7 +26,7 @@ import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoParticipantDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.tags.domain.Tag;
 import org.prgms.locomocoserver.tags.domain.TagRepository;
@@ -141,12 +141,12 @@ public class MogakkoService {
 
     public Mogakko getByIdNotDeleted(Long id) {
         return mogakkoRepository.findByIdAndDeletedAtIsNull(id)
-            .orElseThrow(() -> new MogakkoException(MogakkoErrorCode.NOT_FOUND));
+            .orElseThrow(() -> new MogakkoException(MogakkoErrorType.NOT_FOUND));
     }
 
     private static void validateCreator(MogakkoUpdateRequestDto requestDto, Mogakko foundMogakko) {
         if (!foundMogakko.isSameCreatorId(requestDto.creatorId())) {
-            throw new MogakkoException(MogakkoErrorCode.PROCESS_FORBIDDEN);
+            throw new MogakkoException(MogakkoErrorType.PROCESS_FORBIDDEN);
         }
     }
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -24,7 +24,7 @@ import org.prgms.locomocoserver.global.common.BaseEntity;
 import org.prgms.locomocoserver.inquiries.domain.Inquiry;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.user.domain.User;
 
@@ -173,6 +173,6 @@ public class Mogakko extends BaseEntity {
 
     private MogakkoException generateCreateException(String msg) {
         return new MogakkoException(
-            MogakkoErrorCode.CREATE_FORBIDDEN.appendMessage(msg));
+            MogakkoErrorType.CREATE_FORBIDDEN.appendMessage(msg));
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorType.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MogakkoErrorCode {
+public enum MogakkoErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, 700, "해당 모각코를 찾을 수 없습니다."),
     PROCESS_FORBIDDEN(HttpStatus.FORBIDDEN, 701, "해당 모각코 작성자만 처리할 수 있습니다."),
     CREATE_FORBIDDEN(HttpStatus.BAD_REQUEST, 702, "다음 이유로 생성이 불가능합니다. - "),
@@ -14,13 +14,13 @@ public enum MogakkoErrorCode {
     private int code;
     private String message;
 
-    MogakkoErrorCode(HttpStatus httpStatus, int code, String message) {
+    MogakkoErrorType(HttpStatus httpStatus, int code, String message) {
         this.httpStatus = httpStatus;
         this.code = code;
         this.message = message;
     }
 
-    public MogakkoErrorCode appendMessage(String msg) {
+    public MogakkoErrorType appendMessage(String msg) {
         this.message += msg;
         return this;
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoException.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoException.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 
 @Getter
 public class MogakkoException extends RuntimeException{
-    private final MogakkoErrorCode errorCode;
+    private final MogakkoErrorType errorType;
 
-    public MogakkoException(MogakkoErrorCode errorCode) {
-        this.errorCode = errorCode;
+    public MogakkoException(MogakkoErrorType errorType) {
+        this.errorType = errorType;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -17,7 +17,7 @@ import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoLikeDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,7 +48,7 @@ public class MogakkoController {
         searchVal = searchVal.strip();
 
         if (searchVal.length() == 1) {
-            throw new MogakkoException(MogakkoErrorCode.TOO_LITTLE_INPUT.appendMessage("2"));
+            throw new MogakkoException(MogakkoErrorType.TOO_LITTLE_INPUT.appendMessage("2"));
         }
 
         List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags,

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoTest.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorCode;
+import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.enums.Gender;
@@ -51,7 +51,7 @@ class MogakkoTest {
             () -> Mogakko.builder().title("title").content("content").views(1L)
                 .likeCount(0).startTime(startTime).deadline(deadline).endTime(endTime)
                 .maxParticipants(10).creator(testUser).build());
-        assertThat(mogakkoException.getErrorCode()).isEqualTo(MogakkoErrorCode.CREATE_FORBIDDEN);
+        assertThat(mogakkoException.getErrorType()).isEqualTo(MogakkoErrorType.CREATE_FORBIDDEN);
     }
 
     @Test
@@ -67,7 +67,7 @@ class MogakkoTest {
             () -> Mogakko.builder().title("title").content("content").views(1L)
                 .likeCount(0).startTime(startTime).deadline(deadline).endTime(endTime)
                 .maxParticipants(10).creator(testUser).build());
-        assertThat(mogakkoException.getErrorCode()).isEqualTo(MogakkoErrorCode.CREATE_FORBIDDEN);
+        assertThat(mogakkoException.getErrorType()).isEqualTo(MogakkoErrorType.CREATE_FORBIDDEN);
     }
 
     @Test
@@ -82,7 +82,7 @@ class MogakkoTest {
                 .startTime(LocalDateTime.now()).deadline(LocalDateTime.now())
                 .endTime(LocalDateTime.now())
                 .maxParticipants(10).creator(testUser).build());
-        assertThat(mogakkoException.getErrorCode()).isEqualTo(MogakkoErrorCode.CREATE_FORBIDDEN);
+        assertThat(mogakkoException.getErrorType()).isEqualTo(MogakkoErrorType.CREATE_FORBIDDEN);
     }
 
     @Test
@@ -97,7 +97,7 @@ class MogakkoTest {
                 .startTime(LocalDateTime.now()).deadline(LocalDateTime.now())
                 .endTime(LocalDateTime.now())
                 .maxParticipants(10).creator(testUser).build());
-        assertThat(mogakkoException.getErrorCode()).isEqualTo(MogakkoErrorCode.CREATE_FORBIDDEN);
+        assertThat(mogakkoException.getErrorType()).isEqualTo(MogakkoErrorType.CREATE_FORBIDDEN);
     }
 
     @Test
@@ -112,7 +112,7 @@ class MogakkoTest {
                 .startTime(LocalDateTime.now()).deadline(LocalDateTime.now())
                 .endTime(LocalDateTime.now())
                 .maxParticipants(maxParticipants).creator(testUser).build());
-        assertThat(mogakkoException.getErrorCode()).isEqualTo(MogakkoErrorCode.CREATE_FORBIDDEN);
+        assertThat(mogakkoException.getErrorType()).isEqualTo(MogakkoErrorType.CREATE_FORBIDDEN);
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #178 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* 서버에서 에러 발생 시, 해당 에러 내용을 슬랙에서 보여줍니다. 아래는 예시.
![image](https://github.com/Ogu-Family/Locomoco_BE/assets/76583883/382dd77b-d3c6-4806-99ed-6267c3bba9ac)

프론트나 백이나 서버로 직접 접근해 예외를 확인해야 하는 비효율성을 많이 해결해 줄 것이라 생각합니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
따로 슬랙용 서비스 클래스로 빼고, 전체 예외를 핸들링하는 클래스 메서드 각각에 `sendAlertLog()`를 넣을 수 밖에 없었는데 코드적으로 좀 중복이 있어 보여서 좀 그러네요. 
AOP를 적용해보려 했지만 이러면 메서드의 파라미터를 알아야 해서 적용하기 까다로워 포기했습니다. 
코드적으로 어떻게 해야 더 깔끔한지 함께 고민해 보고 싶네요!