### PR TITLE
Test 145 모각코 필터링 서비스 테스트

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -54,12 +54,12 @@ public class MogakkoService {
 
     @Transactional
     public MogakkoCreateResponseDto save(MogakkoCreateRequestDto requestDto) {
+        User creator = userService.getById(requestDto.creatorId());
         Mogakko mogakko = createMogakkoBy(requestDto);
 
         Location location = requestDto.toLocation();
         location.updateMogakko(mogakko);
 
-        User creator = userService.getById(requestDto.creatorId());
         mogakko.updateCreator(creator);
 
         Mogakko savedMogakko = mogakkoRepository.save(mogakko);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -17,8 +17,6 @@ import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoDetailResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoLikeDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoUpdateResponseDto;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoErrorType;
-import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -46,10 +44,6 @@ public class MogakkoController {
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "100") Integer pageSize,
             @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
         searchVal = searchVal.strip();
-
-        if (searchVal.length() == 1) {
-            throw new MogakkoException(MogakkoErrorType.TOO_LITTLE_INPUT.appendMessage("2"));
-        }
 
         List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags,
                 cursor, searchVal, searchType, pageSize);


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #145 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
1. 컨트롤러에 있던 검색 값이 최소 문자 수보다 작으면 예외를 던지도록 하는 코드는 서비스 단으로 옮겼습니다. 물론 컨트롤러에서 필터링을 먼저 해버리는 것도 좋지만, 해당 필터링 메서드를 다른 곳에서 만약 사용한다면 컨트롤러를 거치지 않을 것으로 판단하여 서비스 단으로 옮겼습니다.

2. 모각코 생성 서비스 코드에서는 DTO를 바탕으로 모각코를 생성한 뒤, 유저가 삭제된 유저인지 없는 유저인지 검증을 하는데 이 경우 앞서 모각코를 생성하는 부분이 불필요하게 존재하는 경우가 생깁니다. 그래서 맨 처음 유저 검증을 하도록 생성 메서드를 수정했습니다.

3. 다음 상황에 대한 테스트 코드를 작성했습니다.
* 필터링 정상 처리 테스트
* 최소 문자 수보다 작은 문자로 검색 시 예외가 발생하는지 확인하는 테스트
* 삭제된 사용자 혹은 존재하지 않는 사용자가 모각코를 생성할 수 없음을 검증하는 테스트
* 모각코 생성자가 아닌 유저가 수정하려 할 때, 예외가 발생하는지 확인하는 테스트

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
- 테스트 상황이 위 상황 말고도 더 있을 수 있는데 생각나는 것이 있으시다면 말씀해 주세요. 
- 그 밖에도 위 주요 구현 사항에서 더 효율적인 방식이 있으면 말씀해 주셔도 좋습니다!