### PR TITLE
fix: 도시 검색이 확실하게 되도록 수정

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -15,7 +15,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
 
     @Query(value = "SELECT m.* FROM mogakko m "
         + "JOIN locations l ON (m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND l.mogakko_id = m.id) "
-        + "WHERE MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) "
+        + "WHERE MATCH(l.city) AGAINST(CONCAT('\"', :city, '\"') IN BOOLEAN MODE) "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
     List<Mogakko> findAllByCity(Long cursor, String city, int pageSize, LocalDateTime now);
@@ -24,7 +24,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
         + "FROM mogakko_tags mt "
         + "INNER JOIN mogakko m ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.id = mt.mogakko_id "
         + "INNER JOIN locations l ON l.mogakko_id = m.id "
-        + "WHERE mt.tag_id IN :tagIds AND MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) "
+        + "WHERE mt.tag_id IN :tagIds AND MATCH(l.city) AGAINST(CONCAT('\"', :city, '\"') IN BOOLEAN MODE) "
         + "GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize "
         + "ORDER BY m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
MySQL의 Fulltext index 검색을 사용할 때, match against 구문을 사용하는데, 검색 조건에 띄어쓰기가 있으면 OR 검색을 하여서 발생한 일이었습니다. ("서울특별시 종로구" 로 검색하면 "서울특별시", "종로구" 둘 중 하나라도 포함하면 검색 되었던 것)

이제 정확하게 해당 지역만 검색합니다.
## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
버그 수정으로 빠른 머지하겠습니다!