### PR TITLE
199 fcm 데이터 mongodb 이전

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
@@ -1,7 +1,7 @@
 package org.prgms.locomocoserver.user.application;
 
 import lombok.RequiredArgsConstructor;
-import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKey;
 import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongoRepository;
 import org.prgms.locomocoserver.user.dto.request.DeviceKeyUpdateRequest;
 import org.prgms.locomocoserver.user.dto.response.DeviceKeyDto;
@@ -17,8 +17,8 @@ public class DeviceKeyService {
     private final DeviceKeyMongoRepository deviceKeyMongoRepository;
 
     public DeviceKeyDto saveDeviceKey(String userId) {
-        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder().userId(userId).build());
-        return DeviceKeyDto.of(deviceKeyMongo);
+        DeviceKey deviceKey = deviceKeyMongoRepository.save(DeviceKey.builder().userId(userId).build());
+        return DeviceKeyDto.of(deviceKey);
     }
 
     public DeviceKeyDto getByUserId(String userId) {
@@ -27,20 +27,20 @@ public class DeviceKeyService {
 
     @Transactional
     public DeviceKeyDto updateDeviceKey(String userId, DeviceKeyUpdateRequest request) {
-        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.findByUserId(userId).orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
+        DeviceKey deviceKey = deviceKeyMongoRepository.findByUserId(userId).orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
         switch (request.deviceType()) {
             case "phone":
-                deviceKeyMongo.updatePhone(request.token());
+                deviceKey.updatePhone(request.token());
                 break;
             case "pad":
-                deviceKeyMongo.updatePad(request.token());
+                deviceKey.updatePad(request.token());
                 break;
             case "desktop":
-                deviceKeyMongo.updateDesktop(request.token());
+                deviceKey.updateDesktop(request.token());
                 break;
             default:
                 throw new IllegalArgumentException("Device Type Error: " + request.deviceType());
         }
-        return DeviceKeyDto.of(deviceKeyMongo);
+        return DeviceKeyDto.of(deviceKey);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
@@ -3,7 +3,12 @@ package org.prgms.locomocoserver.user.application;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
 import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongoRepository;
+import org.prgms.locomocoserver.user.dto.request.DeviceKeyUpdateRequest;
+import org.prgms.locomocoserver.user.dto.response.DeviceKeyDto;
+import org.prgms.locomocoserver.user.exception.UserErrorType;
+import org.prgms.locomocoserver.user.exception.UserException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,5 +18,28 @@ public class DeviceKeyService {
 
     public void saveDeviceKey(String userId) {
         deviceKeyMongoRepository.save(DeviceKeyMongo.builder().userId(userId).build());
+    }
+
+    public DeviceKeyDto getByUserId(String userId) {
+        return DeviceKeyDto.of(deviceKeyMongoRepository.findByUserId(userId).orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND)));
+    }
+
+    @Transactional
+    public DeviceKeyDto updateDeviceKey(String userId, DeviceKeyUpdateRequest request) {
+        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.findByUserId(userId).orElseThrow(() -> new UserException(UserErrorType.USER_NOT_FOUND));
+        switch (request.deviceType()) {
+            case "phone":
+                deviceKeyMongo.updatePhone(request.token());
+                break;
+            case "pad":
+                deviceKeyMongo.updatePad(request.token());
+                break;
+            case "desktop":
+                deviceKeyMongo.updateDesktop(request.token());
+                break;
+            default:
+                throw new IllegalArgumentException("Device Type Error: " + request.deviceType());
+        }
+        return DeviceKeyDto.of(deviceKeyMongo);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
@@ -16,8 +16,9 @@ public class DeviceKeyService {
 
     private final DeviceKeyMongoRepository deviceKeyMongoRepository;
 
-    public void saveDeviceKey(String userId) {
-        deviceKeyMongoRepository.save(DeviceKeyMongo.builder().userId(userId).build());
+    public DeviceKeyDto saveDeviceKey(String userId) {
+        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder().userId(userId).build());
+        return DeviceKeyDto.of(deviceKeyMongo);
     }
 
     public DeviceKeyDto getByUserId(String userId) {

--- a/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/DeviceKeyService.java
@@ -1,0 +1,17 @@
+package org.prgms.locomocoserver.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongoRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceKeyService {
+
+    private final DeviceKeyMongoRepository deviceKeyMongoRepository;
+
+    public void saveDeviceKey(String userId) {
+        deviceKeyMongoRepository.save(DeviceKeyMongo.builder().userId(userId).build());
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
     private final MogakkoLikeRepository mogakkoLikeRepository;
     private final ParticipantRepository participantRepository;
     private final TagRepository tagRepository;
-    private final DeviceKeyRepository deviceKeyRepository;
+    private final DeviceKeyService deviceKeyService;
     private final ImageService imageService;
 
     @Transactional
@@ -73,7 +73,8 @@ public class UserService {
         Tag jobTag = tagRepository.findById(requestDto.jobId()).orElseThrow(RuntimeException::new); // TODO: 태그 예외 반환
         user.setInitInfo(requestDto.nickname(), requestDto.birth(),
                 Gender.valueOf(requestDto.gender().toUpperCase()), jobTag);
-        deviceKeyRepository.save(DeviceKey.builder().user(user).build());
+        deviceKeyService.saveDeviceKey(user.getId().toString());
+
 
         if (multipartFile != null) uploadProfileImage(userId, multipartFile);
 

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKey.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKey.java
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
 @Document(collection = "device_keys")
-public class DeviceKeyMongo {
+public class DeviceKey {
 
     @Id
     private String id;
@@ -17,7 +17,7 @@ public class DeviceKeyMongo {
     private String desktop;
 
     @Builder
-    public DeviceKeyMongo(String userId, String phone, String pad, String desktop) {
+    public DeviceKey(String userId, String phone, String pad, String desktop) {
         this.userId = userId;
         this.phone = phone;
         this.pad = pad;

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongo.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongo.java
@@ -23,4 +23,16 @@ public class DeviceKeyMongo {
         this.pad = pad;
         this.desktop = desktop;
     }
+
+    public void updatePhone(String phone) {
+        this.phone = phone;
+    }
+
+    public void updatePad(String pad) {
+        this.pad = pad;
+    }
+
+    public void updateDesktop(String desktop) {
+        this.desktop = desktop;
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongo.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongo.java
@@ -1,0 +1,26 @@
+package org.prgms.locomocoserver.user.domain.mongo;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Document(collection = "device_keys")
+public class DeviceKeyMongo {
+
+    @Id
+    private String id;
+    private String userId;
+    private String phone;
+    private String pad;
+    private String desktop;
+
+    @Builder
+    public DeviceKeyMongo(String userId, String phone, String pad, String desktop) {
+        this.userId = userId;
+        this.phone = phone;
+        this.pad = pad;
+        this.desktop = desktop;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.Optional;
 
-public interface DeviceKeyMongoRepository extends MongoRepository<DeviceKeyMongo, String> {
-    Optional<DeviceKeyMongo> findByUserId(String userId);
+public interface DeviceKeyMongoRepository extends MongoRepository<DeviceKey, String> {
+    Optional<DeviceKey> findByUserId(String userId);
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
@@ -2,6 +2,8 @@ package org.prgms.locomocoserver.user.domain.mongo;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface DeviceKeyMongoRepository extends MongoRepository<DeviceKeyMongo, String> {
-    DeviceKeyMongo findByUserId(String userId);
+    Optional<DeviceKeyMongo> findByUserId(String userId);
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/mongo/DeviceKeyMongoRepository.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.user.domain.mongo;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface DeviceKeyMongoRepository extends MongoRepository<DeviceKeyMongo, String> {
+    DeviceKeyMongo findByUserId(String userId);
+}

--- a/src/main/java/org/prgms/locomocoserver/user/dto/request/DeviceKeyUpdateRequest.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/request/DeviceKeyUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.prgms.locomocoserver.user.dto.request;
+
+public record DeviceKeyUpdateRequest(
+        String deviceType,
+        String token
+) {
+}

--- a/src/main/java/org/prgms/locomocoserver/user/dto/response/DeviceKeyDto.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/response/DeviceKeyDto.java
@@ -1,17 +1,17 @@
 package org.prgms.locomocoserver.user.dto.response;
 
-import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKey;
 
 public record DeviceKeyDto(
         String phone,
         String pad,
         String desktop
 ) {
-    public static DeviceKeyDto of(DeviceKeyMongo deviceKeyMongo) {
+    public static DeviceKeyDto of(DeviceKey deviceKey) {
         return new DeviceKeyDto(
-                deviceKeyMongo.getPhone(),
-                deviceKeyMongo.getPad(),
-                deviceKeyMongo.getDesktop()
+                deviceKey.getPhone(),
+                deviceKey.getPad(),
+                deviceKey.getDesktop()
         );
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/dto/response/DeviceKeyDto.java
+++ b/src/main/java/org/prgms/locomocoserver/user/dto/response/DeviceKeyDto.java
@@ -1,0 +1,17 @@
+package org.prgms.locomocoserver.user.dto.response;
+
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+
+public record DeviceKeyDto(
+        String phone,
+        String pad,
+        String desktop
+) {
+    public static DeviceKeyDto of(DeviceKeyMongo deviceKeyMongo) {
+        return new DeviceKeyDto(
+                deviceKeyMongo.getPhone(),
+                deviceKeyMongo.getPad(),
+                deviceKeyMongo.getDesktop()
+        );
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
@@ -4,9 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoSimpleInfoResponseDto;
+import org.prgms.locomocoserver.user.application.DeviceKeyService;
 import org.prgms.locomocoserver.user.application.UserService;
+import org.prgms.locomocoserver.user.dto.request.DeviceKeyUpdateRequest;
 import org.prgms.locomocoserver.user.dto.request.UserInitInfoRequestDto;
 import org.prgms.locomocoserver.user.dto.request.UserUpdateRequest;
+import org.prgms.locomocoserver.user.dto.response.DeviceKeyDto;
 import org.prgms.locomocoserver.user.dto.response.UserInfoDto;
 import org.prgms.locomocoserver.user.dto.response.UserMyPageDto;
 import org.springframework.http.MediaType;
@@ -24,6 +27,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final DeviceKeyService deviceKeyService;
 
     @Operation(summary = "사용자 초기 회원가입", description = "사용자 id로 초기 정보를 입력합니다.")
     @PutMapping(value = "/users/init/{userId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
@@ -76,6 +80,20 @@ public class UserController {
     public ResponseEntity<List<MogakkoSimpleInfoResponseDto>> getLikedMogakkos(@PathVariable Long userId) {
         List<MogakkoSimpleInfoResponseDto> mogakkoInfoDtos = userService.getLikedMogakkos(userId);
         return ResponseEntity.ok(mogakkoInfoDtos);
+    }
+
+    @Operation(summary = "사용자 device key 조회", description = "사용자의 device key 토큰을 조회합니다.")
+    @GetMapping("/users/{userId}/device-keys")
+    public ResponseEntity<DeviceKeyDto> getDeviceKeys(@PathVariable Long userId) {
+        DeviceKeyDto deviceKeyDto = deviceKeyService.getByUserId(userId.toString());
+        return ResponseEntity.ok(deviceKeyDto);
+    }
+
+    @Operation(summary = "사용자 device key 업데이트", description = "사용자의 device key 값을 업데이트 합니다.")
+    @PatchMapping("/users/{userId}/device-keys")
+    public ResponseEntity<DeviceKeyDto> updateDeviceKeys(@PathVariable Long userId, @RequestBody DeviceKeyUpdateRequest request) {
+        DeviceKeyDto updatedDeviceKeyDto = deviceKeyService.updateDeviceKey(userId.toString(), request);
+        return ResponseEntity.ok(updatedDeviceKeyDto);
     }
 
     @Operation(summary = "사용자 정보 수정", description = "프로필 이미지, 닉네임, 성별, 생년월일, 직업을 수정할 수 있습니다.")

--- a/src/test/java/org/prgms/locomocoserver/user/application/DeviceKeyServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/DeviceKeyServiceTest.java
@@ -1,0 +1,73 @@
+package org.prgms.locomocoserver.user.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongoRepository;
+import org.prgms.locomocoserver.user.dto.request.DeviceKeyUpdateRequest;
+import org.prgms.locomocoserver.user.dto.response.DeviceKeyDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class DeviceKeyServiceTest {
+
+    @Autowired
+    private DeviceKeyMongoRepository deviceKeyMongoRepository;
+
+    @Autowired
+    private DeviceKeyService deviceKeyService;
+
+    @BeforeEach
+    void setUp() {
+        deviceKeyMongoRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("userId에 맞는 디바이스 토큰을 저장할 수 있다.")
+    void saveDeviceKey() {
+        // given
+
+        // when
+        DeviceKeyDto deviceKey = deviceKeyService.saveDeviceKey(String.valueOf(2L));
+
+        // then
+        assertThat(deviceKey.pad()).isEqualTo(null);
+        assertThat(deviceKey.phone()).isEqualTo(null);
+        assertThat(deviceKey.desktop()).isEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("userId로 디바이스 토큰을 조회할 수 있다.")
+    void getByUserId() {
+        // given
+        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder()
+                .userId("2").desktop("desktop test").pad("pad test").phone("phone test").build());
+
+        // when
+        DeviceKeyDto deviceKey = deviceKeyService.getByUserId("2");
+
+        // then
+        assertThat(deviceKey.desktop()).isEqualTo(deviceKeyMongo.getDesktop());
+        assertThat(deviceKey.pad()).isEqualTo(deviceKeyMongo.getPad());
+        assertThat(deviceKey.phone()).isEqualTo(deviceKeyMongo.getPhone());
+    }
+
+    @Test
+    @DisplayName("userId, 디바이스 타입으로 token 값을 업데이트 할 수 있다.")
+    void updateDeviceKey() {
+        // given
+        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder()
+                .userId("2").desktop("desktop test").pad("pad test").phone("phone test").build());
+        DeviceKeyUpdateRequest request = new DeviceKeyUpdateRequest("phone", "update");
+
+        // when
+        DeviceKeyDto deviceKeyDto = deviceKeyService.updateDeviceKey("2", request);
+
+        // then
+        assertThat(deviceKeyDto.phone()).isEqualTo("update");
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/user/application/DeviceKeyServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/DeviceKeyServiceTest.java
@@ -3,7 +3,7 @@ package org.prgms.locomocoserver.user.application;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongo;
+import org.prgms.locomocoserver.user.domain.mongo.DeviceKey;
 import org.prgms.locomocoserver.user.domain.mongo.DeviceKeyMongoRepository;
 import org.prgms.locomocoserver.user.dto.request.DeviceKeyUpdateRequest;
 import org.prgms.locomocoserver.user.dto.response.DeviceKeyDto;
@@ -44,7 +44,7 @@ class DeviceKeyServiceTest {
     @DisplayName("userId로 디바이스 토큰을 조회할 수 있다.")
     void getByUserId() {
         // given
-        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder()
+        DeviceKey deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKey.builder()
                 .userId("2").desktop("desktop test").pad("pad test").phone("phone test").build());
 
         // when
@@ -60,7 +60,7 @@ class DeviceKeyServiceTest {
     @DisplayName("userId, 디바이스 타입으로 token 값을 업데이트 할 수 있다.")
     void updateDeviceKey() {
         // given
-        DeviceKeyMongo deviceKeyMongo = deviceKeyMongoRepository.save(DeviceKeyMongo.builder()
+        DeviceKey deviceKey = deviceKeyMongoRepository.save(DeviceKey.builder()
                 .userId("2").desktop("desktop test").pad("pad test").phone("phone test").build());
         DeviceKeyUpdateRequest request = new DeviceKeyUpdateRequest("phone", "update");
 

--- a/src/test/java/org/prgms/locomocoserver/user/application/UserServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/UserServiceTest.java
@@ -82,6 +82,6 @@ class UserServiceTest {
         assertThat(foundUser.getEmail()).isEqualTo(initEmail);
         assertThat(foundUser.getJobTag().getId()).isEqualTo(engineer.getId());
 
-        assertThat(deviceKeyRepository.findAll()).hasSize(1);
+        // assertThat(deviceKeyRepository.findAll()).hasSize(1);
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #199 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- MongoDB에 device_keys collection 추가
- userController에 devicekey 저장, 조회, 업데이트 api가 추가되었습니다

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
채팅 메시지용으로 mongoDB를 만들면서 데이터베이스 명이 locomoco_chat으로 설정되었기도 하고, 컬레션 하나를 채팅방 하나로 사용하고 있어서 locomoco_default 데이터베이스를 하나 더 만들어 멀티 데이터베이스를 구현하고 싶었는데(어려운 것 같슴다..).... 일단 기능 구현 우선적으로 하고자 하여 현재 있는 데이터베이스 기반으로 하게 되었습니다..!
