### PR TITLE
Feature 203 participants 정보 변경 api 생성

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -16,6 +16,7 @@ import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -44,11 +45,20 @@ public class MogakkoParticipationService {
 
         validateIfDeadlineIsPast(mogakko);
 
-        Participant participant = Participant.builder().mogakko(mogakko).user(user).build();
+        Participant participant = Participant.builder().mogakko(mogakko).user(user).latitude(
+            requestDto.latitude()).longitude(requestDto.longitude()).build();
         mogakko.addParticipant(participant);
         participantRepository.save(participant);
 
         chatRoomService.enterChatRoom(new ChatEnterRequestDto(mogakko.getChatRoom().getId(), user));
+    }
+
+    @Transactional
+    public void update(Long mogakkoId, ParticipationRequestDto requestDto) {
+        Participant participant = participantRepository.findByMogakkoIdAndUserId(mogakkoId,
+            requestDto.userId()).orElseThrow(() -> new RuntimeException("해당하는 참여자가 존재하지 않습니다.")); // TODO: 참가 에러 반환
+
+        participant.updateLocation(requestDto.latitude(), requestDto.longitude());
     }
 
     public void cancel(Long mogakkoId, Long userId) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/Participant.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/participants/Participant.java
@@ -49,10 +49,6 @@ public class Participant {
         this.mogakko = mogakko;
     }
 
-    public void updateUser(User user) {
-        this.user = user;
-    }
-
     public void updateMogakko(Mogakko mogakko) {
         if (Objects.nonNull(mogakko)) {
             mogakko.getParticipants().remove(this);
@@ -60,5 +56,10 @@ public class Participant {
 
         this.mogakko = mogakko;
         mogakko.getParticipants().add(this);
+    }
+
+    public void updateLocation(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
@@ -6,4 +6,7 @@ public record ParticipationRequestDto(@Schema(description = "참여하고자 하
                                       @Schema(description = "참여하고자 하는 유저의 출발 경도", example = "126.97335352452") Double longitude,
                                       @Schema(description = "참여하고자 하는 유저의 출발 위도", example = "26.83783263") Double latitude) {
 
+    public ParticipationRequestDto(Long userId) {
+        this(userId, null, null);
+    }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/ParticipationRequestDto.java
@@ -2,6 +2,8 @@ package org.prgms.locomocoserver.mogakkos.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record ParticipationRequestDto(@Schema(description = "참여하고자 하는 유저 id", example = "1") Long userId) {
+public record ParticipationRequestDto(@Schema(description = "참여하고자 하는 유저 id", example = "1") Long userId,
+                                      @Schema(description = "참여하고자 하는 유저의 출발 경도", example = "126.97335352452") Double longitude,
+                                      @Schema(description = "참여하고자 하는 유저의 출발 위도", example = "26.83783263") Double latitude) {
 
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoParticipationController.java
@@ -12,6 +12,7 @@ import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,6 +50,19 @@ public class MogakkoParticipationController {
         @Parameter(description = "모각코 id", example = "1") @PathVariable Long id,
         @Parameter(description = "참여를 원하는 유저 id") @RequestBody ParticipationRequestDto requestDto) {
         participationService.participate(id, requestDto);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "모각코 참여자 정보 수정", description = "특정 모각코 참여자의 정보를 변경합니다. 참여자의 출발 위치를 수정할 때 주로 사용합니다.")
+    @ApiResponses(
+        @ApiResponse(responseCode = "200", description = "참여자 정보 수정 성공")
+    )
+    @PatchMapping("/mogakko/map/{id}/participate")
+    public ResponseEntity<Void> update(
+        @Parameter(description = "모각코 id", example = "1") @PathVariable(name = "id") Long mogakkoId,
+        @Parameter(description = "정보 변경을 원하는 참여자 정보") @RequestBody ParticipationRequestDto requestDto) {
+        participationService.update(mogakkoId, requestDto);
 
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #203 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
모각코 참여자의 위치를 추가하는 api를 만드려 했으나 그냥 `Participants` 정보 수정 기능을 만들었습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
단순 Patch 기능입니다. 그런데 컨트롤러에서 DTO에 수정하고자 하는 유저 id도 넣었는데 이것을 쿼리 파라미터로 넣는 게 나은지 고민입니다. 지금은 갑자기 후자로 좀 마음이 가는데 의견 있으시면 남겨주세요!