### PR TITLE
fix #208: 모각코 에러 로그 메시지가 계속 추가되는 현상 수정

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/exception/MogakkoErrorType.java
@@ -8,10 +8,10 @@ public enum MogakkoErrorType {
     NOT_FOUND(HttpStatus.NOT_FOUND, 700, "해당 모각코를 찾을 수 없습니다."),
     PROCESS_FORBIDDEN(HttpStatus.FORBIDDEN, 701, "해당 모각코 작성자만 처리할 수 있습니다."),
     CREATE_FORBIDDEN(HttpStatus.BAD_REQUEST, 702, "다음 이유로 생성이 불가능합니다. - "),
-    TOO_LITTLE_INPUT(HttpStatus.BAD_REQUEST, 703, "입력 값이 최소한 다음 길이보다 길어야 합니다 - ");
+    TOO_LITTLE_INPUT(HttpStatus.BAD_REQUEST, 703, "입력 길이가 너무 짧습니다.");
 
-    private HttpStatus httpStatus;
-    private int code;
+    private final HttpStatus httpStatus;
+    private final int code;
     private String message;
 
     MogakkoErrorType(HttpStatus httpStatus, int code, String message) {
@@ -21,7 +21,14 @@ public enum MogakkoErrorType {
     }
 
     public MogakkoErrorType appendMessage(String msg) {
-        this.message += msg;
+        StringBuilder sb = new StringBuilder();
+
+        switch (this) {
+            case CREATE_FORBIDDEN -> sb.append("다음과 같은 이유로 생성이 불가능합니다 - ");
+            case TOO_LITTLE_INPUT -> sb.append("입력 길이가 최소한 다음 길이 이상은 되어야 합니다 - ");
+        }
+
+        this.message = sb.append(msg).toString();
         return this;
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #208 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
기존에는 메시지 부분에 고정된 값이 있고, 추가적 요소를 메시지 뒤에 추가하는 형식으로 구현했습니다. 그러나 이 경우, 로그에 메시지가 계속 쌓이는 버그가 있었습니다.
![image](https://github.com/Ogu-Family/Locomoco_BE/assets/76583883/574388d1-d069-43ae-afaf-240fc2b7a7fc)

현재는 코드 부분에 아예 메시지 부분을 새로 초기화하도록 하여서 수정했습니다.
![image](https://github.com/Ogu-Family/Locomoco_BE/assets/76583883/12007fda-aa16-4cbb-9fdb-44e53b872bb5)


## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
간단하지만 이 코드가 제대로 잘 작성된 것인지만 다시 확인해 주세요.