### PR TITLE
Fix 213 삭제된 문의가 디테일 페이지에서 보여지는 문제 수정

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -22,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class InquiryService {
+    private static final int PAGE_SIZE = 20;
+
     private final InquiryRepository inquiryRepository;
     private final MogakkoRepository mogakkoRepository;
     private final UserRepository userRepository;
@@ -54,13 +56,13 @@ public class InquiryService {
         List<Inquiry> foundInquries;
 
         if (mogakkoId == null && userId == null) { // querydsl 도입 시 동적 쿼리로 리팩터링
-            foundInquries = inquiryRepository.findAll(cursor);
+            foundInquries = inquiryRepository.findAll(cursor, PAGE_SIZE);
         } else if (mogakkoId == null) {
-            foundInquries = inquiryRepository.findAllByUser(cursor, userId);
+            foundInquries = inquiryRepository.findAllByUser(cursor, userId, PAGE_SIZE);
         } else if (userId == null) {
-            foundInquries = inquiryRepository.findAllByMogakko(cursor, mogakkoId);
+            foundInquries = inquiryRepository.findAllByMogakko(cursor, mogakkoId, PAGE_SIZE);
         } else {
-            foundInquries = inquiryRepository.findAllByMogakkoAndUser(cursor, mogakkoId, userId);
+            foundInquries = inquiryRepository.findAllByMogakkoAndUser(cursor, mogakkoId, userId, PAGE_SIZE);
         }
 
         return foundInquries.stream().map(

--- a/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/application/InquiryService.java
@@ -72,7 +72,7 @@ public class InquiryService {
     @Transactional
     public void delete(Long id, Long userId) {
         Inquiry inquiry = inquiryRepository.findByIdAndDeletedAtIsNull(id)
-            .orElseThrow(RuntimeException::new); // TODO: 문의 예외 반환
+            .orElseThrow(() -> new RuntimeException("삭제할 문의를 찾을 수 없습니다.")); // TODO: 문의 예외 반환
 
         validateUser(userId, inquiry);
 
@@ -83,7 +83,7 @@ public class InquiryService {
         boolean isSameUser = foundInquiry.getUser().getId().equals(inquiryUserId);
 
         if (!isSameUser) {
-            throw new RuntimeException(); // TODO: 유저 예외 반환
+            throw new RuntimeException("문의를 작성한 유저가 아닙니다."); // TODO: 문의 예외 반환
         }
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/inquiries/domain/InquiryRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/inquiries/domain/InquiryRepository.java
@@ -7,24 +7,28 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
     Optional<Inquiry> findByIdAndDeletedAtIsNull(Long id);
+
     @Query(value = "SELECT i.* FROM inquiries i WHERE id < :cursor "
         + "ORDER BY i.created_at DESC "
-        + "LIMIT 20", nativeQuery = true)
-    List<Inquiry> findAll(Long cursor);
+        + "LIMIT :pageSize", nativeQuery = true)
+    List<Inquiry> findAll(Long cursor, int pageSize);
+
     @Query(value = "SELECT i.* FROM inquiries i "
         + "INNER JOIN users u ON i.id < :cursor AND u.id = :userId AND i.user_id = u.id "
         + "ORDER BY i.created_at DESC "
-        + "LIMIT 20", nativeQuery = true)
-    List<Inquiry> findAllByUser(Long cursor, Long userId);
+        + "LIMIT :pageSize", nativeQuery = true)
+    List<Inquiry> findAllByUser(Long cursor, Long userId, int pageSize);
+
     @Query(value = "SELECT i.* FROM inquiries i "
-        + "INNER JOIN mogakko m ON i.id < :cursor AND m.id = :mogakkoId AND i.mogakko_id = m.id "
+        + "INNER JOIN mogakko m ON i.id < :cursor AND m.id = :mogakkoId AND i.mogakko_id = m.id AND i.deleted_at IS NULL "
         + "ORDER BY i.created_at DESC "
-        + "LIMIT 20", nativeQuery = true)
-    List<Inquiry> findAllByMogakko(Long cursor, Long mogakkoId);
+        + "LIMIT :pageSize", nativeQuery = true)
+    List<Inquiry> findAllByMogakko(Long cursor, Long mogakkoId, int pageSize);
+
     @Query(value = "SELECT i.* FROM inquiries i "
         + "INNER JOIN mogakko m ON i.id < :cursor AND m.id = :mogakkoId AND i.mogakko_id = m.id "
         + "INNER JOIN users u ON u.id = :userId AND i.user_id = u.id "
         + "ORDER BY i.created_at DESC "
-        + "LIMIT 20", nativeQuery = true)
-    List<Inquiry> findAllByMogakkoAndUser(Long cursor, Long mogakkoId, Long userId);
+        + "LIMIT :pageSize", nativeQuery = true)
+    List<Inquiry> findAllByMogakkoAndUser(Long cursor, Long mogakkoId, Long userId, int pageSize);
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #213 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
삭제된 문의가 모각코 디테일 페이지에서 보여지는 문제가 있었습니다.
![image](https://github.com/Ogu-Family/Locomoco_BE/assets/76583883/deb1b138-2aae-4d09-aa2a-9b622e5c6bcd)
위에서 빨간색 문의는 실제로는 삭제된 문의이지만 여전히 보입니다.

문의를 가져오는 쿼리에서 deleted_at is null 을 누락한 것을 이유로 보고 수정합니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
이 PR 머지 후, 전체적으로 문의 테스트를 만들 계획입니다. 애플리케이션 버그이므로 일단 빠르게 머지하겠습니다!