### PR TITLE
Test 98 모각코 참여 검증

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationService.java
@@ -41,7 +41,7 @@ public class MogakkoParticipationService {
 
     @Transactional
     public void participate(Long mogakkoId, ParticipationRequestDto requestDto) {
-        Mogakko mogakko = mogakkoRepository.findByIdAndDeletedAtIsNull(mogakkoId)
+        Mogakko mogakko = mogakkoRepository.findByIdAndDeletedAtIsNullForUpdate(mogakkoId)
             .orElseThrow(() -> new MogakkoException(MogakkoErrorType.NOT_FOUND));
         User user = userService.getById(requestDto.userId());
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Mogakko.java
@@ -91,7 +91,7 @@ public class Mogakko extends BaseEntity {
     public Mogakko(Long id, String title, String content, LocalDateTime startTime,
         LocalDateTime endTime, LocalDateTime deadline, int likeCount, int maxParticipants,
         long views, List<MogakkoTag> mogakkoTags, List<Participant> participants,
-        List<Inquiry> inquiries, User creator, ChatRoom chatRoom) {
+        List<Inquiry> inquiries, User creator, ChatRoom chatRoom) { // TODO: VO로 세분화
         this.id = id;
         this.title = title;
         this.content = content;
@@ -157,7 +157,7 @@ public class Mogakko extends BaseEntity {
         if (this.startTime.isAfter(this.endTime) || this.deadline.isAfter(this.endTime)) {
             throw generateCreateException("날짜 설정이 잘못되었습니다!");
         }
-        if (this.maxParticipants < 0 || this.maxParticipants > DEFAULT_MAX_PARTICIPANTS) {
+        if (this.maxParticipants <= 0 || this.maxParticipants > DEFAULT_MAX_PARTICIPANTS) {
             throw generateCreateException("최대 인원 수가 잘못되었습니다!");
         }
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -1,10 +1,12 @@
 package org.prgms.locomocoserver.mogakkos.domain;
 
+import jakarta.persistence.LockModeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +14,10 @@ import org.springframework.data.repository.query.Param;
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
 
     Optional<Mogakko> findByIdAndDeletedAtIsNull(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Mogakko m WHERE m.id = :id AND m.deletedAt IS NULL")
+    Optional<Mogakko> findByIdAndDeletedAtIsNullForUpdate(Long id); // 이 코드는 추후 따로 클래스 분리를 할 수도 있음
 
     @Query(value = "SELECT m.* FROM mogakko m "
         + "JOIN locations l ON (m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND l.mogakko_id = m.id) "

--- a/src/test/java/org/prgms/locomocoserver/global/TestFactory.java
+++ b/src/test/java/org/prgms/locomocoserver/global/TestFactory.java
@@ -69,6 +69,7 @@ public class TestFactory {
                 .startTime(LocalDateTime.now().plusDays(3))
                 .endTime(LocalDateTime.now().plusDays(3).plusHours(2))
                 .deadline(LocalDateTime.now().plusDays(1))
+                .maxParticipants(5)
                 .likeCount(0)
                 .build();
     }

--- a/src/test/java/org/prgms/locomocoserver/inquiries/application/InquiryServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/inquiries/application/InquiryServiceTest.java
@@ -6,9 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.prgms.locomocoserver.global.TestFactory.createMogakko;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -56,10 +56,7 @@ class InquiryServiceTest {
         User user = User.builder().nickname("생성자").email("cho@gmail.com").birth(LocalDate.EPOCH)
             .gender(Gender.MALE).temperature(36.5).provider("github")
             .build();
-        Mogakko mogakko = Mogakko.builder().title("title").content("제곧내").views(20).likeCount(10)
-            .startTime(LocalDateTime.now()).endTime(LocalDateTime.now().plusHours(2))
-            .deadline(LocalDateTime.now().plusHours(1)).creator(user)
-            .build();
+        Mogakko mogakko = createMogakko(user);
         Inquiry inquiry = Inquiry.builder().user(user).mogakko(mogakko).content(content)
             .build();
 
@@ -113,7 +110,7 @@ class InquiryServiceTest {
         long inquiryId = 1L;
         long writerId = 2L;
         User writer = TestFactory.createUser();
-        Mogakko mogakko = TestFactory.createMogakko(writer);
+        Mogakko mogakko = createMogakko(writer);
         Inquiry inquiry = Inquiry.builder().user(writer).mogakko(mogakko).content("content")
             .build();
 
@@ -138,7 +135,7 @@ class InquiryServiceTest {
         long inquiryId = 1L;
         long writerId = 2L;
         User writer = TestFactory.createUser();
-        Mogakko mogakko = TestFactory.createMogakko(writer);
+        Mogakko mogakko = createMogakko(writer);
         Inquiry inquiry = Inquiry.builder().user(writer).mogakko(mogakko).content("content")
             .build();
 
@@ -169,7 +166,7 @@ class InquiryServiceTest {
         String deletedContent = "삭제된 문의";
         User mogakkoWriter = TestFactory.createUser();
         User inquiryWriter = TestFactory.createUser();
-        Mogakko mogakko = TestFactory.createMogakko(mogakkoWriter);
+        Mogakko mogakko = createMogakko(mogakkoWriter);
 
         setId(inquiryWriter, inquiryWriterId);
         setId(mogakko, mogakkoId);
@@ -208,7 +205,7 @@ class InquiryServiceTest {
         String deletedContent = "삭제된 문의";
         User mogakkoWriter = TestFactory.createUser();
         User inquiryWriter = TestFactory.createUser();
-        Mogakko mogakko = TestFactory.createMogakko(mogakkoWriter);
+        Mogakko mogakko = createMogakko(mogakkoWriter);
 
         setId(inquiryWriter, inquiryWriterId);
         setId(mogakko, mogakkoId);
@@ -246,7 +243,7 @@ class InquiryServiceTest {
         String deletedContent = "삭제된 문의";
         User mogakkoWriter = TestFactory.createUser();
         User inquiryWriter = TestFactory.createUser();
-        Mogakko mogakko = TestFactory.createMogakko(mogakkoWriter);
+        Mogakko mogakko = createMogakko(mogakkoWriter);
 
         setId(inquiryWriter, inquiryWriterId);
         setId(mogakko, mogakkoId);
@@ -284,8 +281,8 @@ class InquiryServiceTest {
         String content = "작성된 문의";
         User mogakkoWriter = TestFactory.createUser();
         User inquiryWriter = TestFactory.createUser();
-        Mogakko mogakko1 = TestFactory.createMogakko(mogakkoWriter);
-        Mogakko mogakko2 = TestFactory.createMogakko(mogakkoWriter);
+        Mogakko mogakko1 = createMogakko(mogakkoWriter);
+        Mogakko mogakko2 = createMogakko(mogakkoWriter);
 
         setId(inquiryWriter, inquiryWriterId);
         setId(mogakko1, mogakko1Id);

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoParticipationServiceTest.java
@@ -1,0 +1,233 @@
+package org.prgms.locomocoserver.mogakkos.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.prgms.locomocoserver.global.TestFactory.createMogakko;
+import static org.prgms.locomocoserver.global.TestFactory.createUser;
+
+import ch.qos.logback.core.util.ExecutorServiceUtil;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.bson.assertions.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
+import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
+import org.prgms.locomocoserver.image.domain.ImageRepository;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
+import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
+import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
+import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
+import org.prgms.locomocoserver.mogakkos.dto.response.ParticipationCheckingDto;
+import org.prgms.locomocoserver.user.domain.User;
+import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MogakkoParticipationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MogakkoParticipationTest.class);
+    @Autowired
+    MogakkoService mogakkoService;
+    @Autowired
+    MogakkoParticipationService mogakkoParticipationService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    MogakkoRepository mogakkoRepository;
+    @Autowired
+    ImageRepository imageRepository;
+    @Autowired
+    ParticipantRepository participantRepository;
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+    @Autowired
+    ChatParticipantRepository chatParticipantRepository;
+    @Autowired
+    MogakkoLocationRepository locationRepository;
+
+    User testCreator;
+    Mogakko testMogakko;
+
+    @BeforeEach
+    void setUp() {
+        testCreator = createUser();
+        testMogakko = createMogakko(testCreator);
+
+        imageRepository.save(testCreator.getProfileImage());
+        userRepository.save(testCreator);
+
+        Long savedMogakkoId = mogakkoService.save(
+            new MogakkoCreateRequestDto(testCreator.getId(), testMogakko.getTitle(),
+                new LocationInfoDto("", 127.52d, 27.8621d, null), testMogakko.getStartTime(),
+                testMogakko.getEndTime(), testMogakko.getDeadline(),
+                testMogakko.getMaxParticipants(),
+                testMogakko.getContent(), Collections.EMPTY_LIST)).id();
+
+        testMogakko = mogakkoRepository.findById(savedMogakkoId)
+            .orElseThrow(() -> new RuntimeException("mogakko not found"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        log.info("청소 시작");
+        chatParticipantRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        participantRepository.deleteAll();
+        locationRepository.deleteAll();
+        mogakkoRepository.deleteAll();
+        userRepository.deleteAll();
+        imageRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("참여 중인 모각코에 중복 참여 신청은 불가능하다.")
+    void fail_participate_in_mogakko_already_belong_to() {
+        // given
+        Long mogakkoId = testMogakko.getId();
+        ParticipationRequestDto requestDto = new ParticipationRequestDto(testCreator.getId());
+
+        // when then
+        assertThatThrownBy(() -> mogakkoParticipationService.participate(mogakkoId, requestDto))
+            .isInstanceOf(RuntimeException.class).hasMessageContaining("이미 참여한 유저입니다."); // TODO: 참여 예외 반환
+    }
+
+    @Test
+    @DisplayName("모각코 작성자가 참여를 취소할 수는 없다.")
+    void fail_cancel_to_participate() {
+        // given
+        Long mogakkoId = testMogakko.getId();
+        Long creatorId = testCreator.getId();
+
+        ThrowingCallable cancelFunc = () -> mogakkoParticipationService.cancel(
+            mogakkoId, creatorId);
+
+        // when then
+        assertThatThrownBy(cancelFunc).isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("모각코 생성자가 참여를 취소할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("(동시성) 참여 인원이 다 차면 더 이상 참여할 수 없다.")
+    void fail_participate_in_mogakko_when_it_is_full() throws Exception {
+        // given
+        Long mogakkoId = testMogakko.getId();
+        int usersNum = testMogakko.getMaxParticipants() + 10;
+
+        ThreadPoolExecutor threadPoolExecutor = ExecutorServiceUtil.newThreadPoolExecutor();
+        threadPoolExecutor.setMaximumPoolSize(usersNum);
+
+        List<User> users = IntStream.range(0, usersNum).mapToObj(i -> createUser()).toList();
+        users.forEach(u -> imageRepository.save(u.getProfileImage()));
+        userRepository.saveAll(users);
+        List<ParticipationRequestDto> participationRequestDtos = users.stream()
+            .map(u -> new ParticipationRequestDto(u.getId(), null, null)).toList();
+
+        CountDownLatch countDownLatch = new CountDownLatch(usersNum);
+
+        // when
+        AtomicInteger overCount = new AtomicInteger();
+
+        participationRequestDtos.forEach(dto ->
+            threadPoolExecutor.execute(
+                () -> {
+                    try {
+                        mogakkoParticipationService.participate(mogakkoId, dto);
+                    } catch (Exception e) {
+                        log.info("예외 발생");
+                        overCount.getAndIncrement();
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                })
+        );
+        countDownLatch.await(5000, TimeUnit.MILLISECONDS);
+
+        // then
+        assertThat(overCount.get()).isEqualTo(usersNum - testMogakko.getMaxParticipants() + 1);
+    }
+
+    @Test
+    @DisplayName("참여자의 참여 정보를 업데이트할 수 있다.")
+    void success_update_info() {
+        // given
+        double latitude = 27.12345678999999d;
+        double longitude = 127.12423d;
+        ParticipationRequestDto requestDto = new ParticipationRequestDto(testCreator.getId(),
+            longitude, latitude);
+
+        // when
+        mogakkoParticipationService.update(testMogakko.getId(), requestDto);
+
+        // then
+        Participant participant = participantRepository.findByMogakkoIdAndUserId(
+            testMogakko.getId(), testCreator.getId()).orElseThrow(RuntimeException::new);
+
+        double columnPointLimit = 0.0000000001d;
+        assertThat(participant.getLongitude()).isEqualTo(longitude, within(columnPointLimit));
+        assertThat(participant.getLatitude()).isEqualTo(latitude, within(columnPointLimit));
+    }
+
+    @Test
+    @DisplayName("모각코 참여를 취소할 수 있다.")
+    void success_cancel_to_participate_in_mogakko() throws Exception {
+        // given
+        User user1 = createUser();
+        User user2 = createUser();
+        List<User> users = List.of(user1, user2);
+
+        users.stream().map(User::getProfileImage).forEach(imageRepository::save);
+        userRepository.saveAll(users);
+
+        users.forEach(user -> mogakkoParticipationService.participate(testMogakko.getId(), new ParticipationRequestDto(user.getId())));
+
+        // when
+        CountDownLatch countDownLatch = new CountDownLatch(users.size());
+
+        users.forEach(user -> CompletableFuture.runAsync(() -> {
+            mogakkoParticipationService.cancel(testMogakko.getId(), user.getId());
+            countDownLatch.countDown();
+        }));
+
+        if (!countDownLatch.await(1000, TimeUnit.MILLISECONDS)) {
+            Assertions.fail();
+        }
+
+        // then
+        List<Participant> participants = participantRepository.findAllByMogakkoId(
+            testMogakko.getId());
+
+        assertThat(participants).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("특정 유저가 특정 모각코에 참여하고 있는지 아닌지 확인할 수 있다.")
+    void success_check_whether_user_participate_in_mogakko() {
+        // when
+        ParticipationCheckingDto checkedTrueDto = mogakkoParticipationService.check(testMogakko.getId(),
+            testCreator.getId());
+        ParticipationCheckingDto checkedFalseDto = mogakkoParticipationService.check(testMogakko.getId(),
+            testCreator.getId() + 1L);
+
+        // then
+        assertThat(checkedTrueDto.isParticipated()).isTrue();
+        assertThat(checkedFalseDto.isParticipated()).isFalse();
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -117,7 +117,7 @@ class MogakkoServiceTest {
         testMogakko = Mogakko.builder().title("title").content("제곧내").views(20).likeCount(10)
             .startTime(LocalDateTime.now())
             .endTime(LocalDateTime.now().plusHours(2)).deadline(LocalDateTime.now().plusHours(1))
-            .creator(setUpUser1).build();
+            .maxParticipants(10).creator(setUpUser1).build();
 
         mogakkoRepository.save(testMogakko);
         tagRepository.findAll().forEach(tag -> {
@@ -198,7 +198,7 @@ class MogakkoServiceTest {
         assertThat(responseDto.creatorInfo()).isNotNull();
         assertThat(responseDto.creatorInfo().nickname()).isEqualTo("생성자");
         assertThat(responseDto.participants()).hasSize(1);
-        assertThat(responseDto.mogakkoInfo().title()).isEqualTo("title");
+        assertThat(responseDto.mogakkoInfo().title()).isEqualTo(testMogakko.getTitle());
     }
 
     @Test

--- a/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/domain/UserRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.prgms.locomocoserver.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.prgms.locomocoserver.global.TestFactory.createMogakko;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,9 +40,7 @@ class UserRepositoryTest {
 
         userRepository.saveAll(List.of(user1, user2));
 
-        Mogakko mogakko = Mogakko.builder().title("title").content("content").startTime(
-                startTime).endTime(startTime.plusHours(2)).deadline(startTime.plusHours(1))
-            .likeCount(0).views(0).creator(user1).build();
+        Mogakko mogakko = createMogakko(user1);
 
         Participant participant1 = participantRepository.save(
             Participant.builder().user(user1).build());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #98 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* OSIV로 인해 잊고 있었던 `@Transactional` 어노테이션을 `participate()` 메서드에 추가해 주었습니다.
* 모각코를 가져올 때, 베타 락을 거는 쿼리를 추가했습니다. 이것은 사용자가 특정 모각코에 참가할 때 사용되며, 이것을 추가한 이유는 동시다발적으로 모각코 참여를 할 경우 정원 이상으로 모각코 참여가 가능해지기 때문입니다.
* 참여와 관련된 서비스 테스트 코드를 작성했습니다.
* 모각코 정원이 0명이어도 생성 가능한 버그를 수정했습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
테스트 코드는 훑어만 주시고 그 외 사항들에 대해 의견이 있으시면 적어주세요. (베타 락, 트랜잭션 어노테이션이 나중에 문제는 안일으킬지 등)