### PR TITLE
Feat 222 모각코 법정동 추가

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MidpointService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MidpointService.java
@@ -46,7 +46,7 @@ public class MidpointService {
         Mogakko mogakko = mogakkoRepository.findById(mogakkoId).orElseThrow(() -> new MogakkoException(
             MogakkoErrorType.NOT_FOUND));
 
-        midpoint.update(recommend.getLatitude(), recommend.getLongitude(), recommend.getAddress(), recommend.getPlaceName(), mogakko);
+        midpoint.update(recommend.getLatitude(), recommend.getLongitude(), recommend.getAddressInfo(), recommend.getPlaceName(), mogakko);
 
         midpointRepository.save(midpoint);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MidpointService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MidpointService.java
@@ -46,7 +46,7 @@ public class MidpointService {
         Mogakko mogakko = mogakkoRepository.findById(mogakkoId).orElseThrow(() -> new MogakkoException(
             MogakkoErrorType.NOT_FOUND));
 
-        midpoint.update(recommend.getLatitude(), recommend.getLongitude(), recommend.getAddressInfo(), recommend.getPlaceName(), mogakko);
+        midpoint.updateInfo(recommend.getLatitude(), recommend.getLongitude(), recommend.getAddressInfo(), recommend.getPlaceName(), mogakko);
 
         midpointRepository.save(midpoint);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -10,6 +10,7 @@ import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.chat.dto.request.ChatCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
@@ -228,10 +229,12 @@ public class MogakkoService {
         MogakkoLocation mogakkoLocation = mogakkoLocationRepository.findByMogakkoAndDeletedAtIsNull(mogakko)
                 .orElseThrow(RuntimeException::new); // TODO: 적절한 예외 반환 (유저 혹은 장소)
 
+        AddressInfo addressInfo = AddressInfo.builder().address(locationInfoDto.address())
+            .city(locationInfoDto.city()).hCity(
+                locationInfoDto.hCity()).build();
+
         mogakkoLocation.updateInfo(locationInfoDto.latitude(),
-                locationInfoDto.longitude(),
-                locationInfoDto.address(),
-                locationInfoDto.city());
+                locationInfoDto.longitude(), addressInfo);
     }
 
     private void validateFilter(String searchVal) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Location.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Location.java
@@ -1,11 +1,13 @@
 package org.prgms.locomocoserver.mogakkos.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.prgms.locomocoserver.global.common.BaseEntity;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 
 @Getter
 @MappedSuperclass
@@ -17,17 +19,13 @@ public abstract class Location extends BaseEntity { // TODO: 밸류 타입화
     @Column(name = "longitude", columnDefinition = "decimal(13, 10)", nullable = false)
     protected Double longitude;
 
-    @Column(name = "address")
-    protected String address;
+    @Embedded
+    protected AddressInfo addressInfo;
 
-    @Column(name = "city")
-    protected String city;
-
-    protected Location(Double latitude, Double longitude, String address, String city) {
+    protected Location(Double latitude, Double longitude, AddressInfo addressInfo) {
         this.latitude = latitude;
         this.longitude = longitude;
-        this.address = address;
-        this.city = city;
+        this.addressInfo = addressInfo;
     }
 
     public double calDistance(Location l) { // km 단위

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Location.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/Location.java
@@ -26,6 +26,9 @@ public abstract class Location extends BaseEntity { // TODO: 밸류 타입화
         this.latitude = latitude;
         this.longitude = longitude;
         this.addressInfo = addressInfo;
+
+        if (this.addressInfo == null)
+            this.addressInfo = new AddressInfo(null, null, null);
     }
 
     public double calDistance(Location l) { // km 단위

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/location/MogakkoLocation.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/location/MogakkoLocation.java
@@ -36,10 +36,10 @@ public class MogakkoLocation extends Location {
         this.mogakko = mogakko;
     }
 
-    public void updateInfo(double latitude, double longitude, AddressInfo addressInfo) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.addressInfo = addressInfo;
+    public void updateInfo(Double latitude, Double longitude, AddressInfo addressInfo) {
+        this.latitude = latitude == null ? this.latitude : latitude;
+        this.longitude = longitude == null ? this.longitude : longitude;
+        this.addressInfo = addressInfo == null ? this.addressInfo : this.addressInfo.update(addressInfo);
     }
 
     public void updateMogakko(Mogakko mogakko) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/location/MogakkoLocation.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/location/MogakkoLocation.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.domain.Location;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 
 @Entity
 @Getter
@@ -29,18 +30,16 @@ public class MogakkoLocation extends Location {
     protected Mogakko mogakko;
 
     @Builder
-    public MogakkoLocation(Double latitude, Double longitude, String address, String city,
-        Mogakko mogakko, Long id) {
-        super(latitude, longitude, address, city);
+    public MogakkoLocation(Double latitude, Double longitude, AddressInfo addressInfo, Mogakko mogakko, Long id) {
+        super(latitude, longitude, addressInfo);
         this.id = id;
         this.mogakko = mogakko;
     }
 
-    public void updateInfo(double latitude, double longitude, String address, String city) {
+    public void updateInfo(double latitude, double longitude, AddressInfo addressInfo) {
         this.latitude = latitude;
         this.longitude = longitude;
-        this.address = address;
-        this.city = city;
+        this.addressInfo = addressInfo;
     }
 
     public void updateMogakko(Mogakko mogakko) {

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
@@ -46,5 +46,6 @@ public class Midpoint extends Location {
         this.addressInfo = addressInfo == null ? this.addressInfo : this.addressInfo.update(addressInfo);
         this.placeName = placeName == null ? this.placeName : placeName;
         this.mogakko = mogakko == null ? this.mogakko : mogakko;
+        this.updateUpdatedAt();
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
@@ -40,11 +40,11 @@ public class Midpoint extends Location {
         this.mogakko = mogakko;
     }
 
-    public void update(double latitude, double longitude, AddressInfo addressInfo, String placeName, Mogakko mogakko) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.addressInfo = addressInfo;
-        this.placeName = placeName;
-        this.mogakko = mogakko;
+    public void updateInfo(Double latitude, Double longitude, AddressInfo addressInfo, String placeName, Mogakko mogakko) {
+        this.latitude = latitude == null ? this.latitude : latitude;
+        this.longitude = longitude == null ? this.longitude : longitude;
+        this.addressInfo = addressInfo == null ? this.addressInfo : this.addressInfo.update(addressInfo);
+        this.placeName = placeName == null ? this.placeName : placeName;
+        this.mogakko = mogakko == null ? this.mogakko : mogakko;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/midpoint/Midpoint.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.prgms.locomocoserver.mogakkos.domain.Location;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 
 @Entity
 @Getter
@@ -31,18 +32,18 @@ public class Midpoint extends Location {
     protected Mogakko mogakko;
 
     @Builder
-    public Midpoint(double latitude, double longitude, String address, String city, Long id, String placeName,
+    public Midpoint(double latitude, double longitude, AddressInfo addressInfo, Long id, String placeName,
         Mogakko mogakko) {
-        super(latitude, longitude, address, city);
+        super(latitude, longitude, addressInfo);
         this.id = id;
         this.placeName = placeName;
         this.mogakko = mogakko;
     }
 
-    public void update(double latitude, double longitude, String address, String placeName, Mogakko mogakko) {
+    public void update(double latitude, double longitude, AddressInfo addressInfo, String placeName, Mogakko mogakko) {
         this.latitude = latitude;
         this.longitude = longitude;
-        this.address = address;
+        this.addressInfo = addressInfo;
         this.placeName = placeName;
         this.mogakko = mogakko;
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/vo/AddressInfo.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/vo/AddressInfo.java
@@ -13,18 +13,26 @@ import lombok.NoArgsConstructor;
 public class AddressInfo {
 
     @Column(name = "address")
-    protected String address;
+    private String address;
 
     @Column(name = "city")
-    protected String city;
+    private String city;
 
     @Column(name = "h_city")
-    protected String hCity;
+    private String hCity;
 
     @Builder
     public AddressInfo(String address, String city, String hCity) {
         this.address = address;
         this.city = city;
         this.hCity = hCity;
+    }
+
+    public AddressInfo update(AddressInfo addressInfo) {
+        String updateAddress = addressInfo.address == null ? this.address : addressInfo.address;
+        String updateCity = addressInfo.city == null ? this.city : addressInfo.city;
+        String updateHCity = addressInfo.hCity == null ? this.hCity : addressInfo.hCity;
+
+        return new AddressInfo(updateAddress, updateCity, updateHCity);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/vo/AddressInfo.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/vo/AddressInfo.java
@@ -1,0 +1,30 @@
+package org.prgms.locomocoserver.mogakkos.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AddressInfo {
+
+    @Column(name = "address")
+    protected String address;
+
+    @Column(name = "city")
+    protected String city;
+
+    @Column(name = "h_city")
+    protected String hCity;
+
+    @Builder
+    public AddressInfo(String address, String city, String hCity) {
+        this.address = address;
+        this.city = city;
+        this.hCity = hCity;
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/LocationInfoDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/LocationInfoDto.java
@@ -2,16 +2,21 @@ package org.prgms.locomocoserver.mogakkos.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 
 public record LocationInfoDto(@Schema(description = "주소", example = "경기도 부천시 소사로 114번길 5") String address,
                               @Schema(description = "위도", example = "31.42958390") Double latitude,
                               @Schema(description = "경도", example = "123.123456789") Double longitude,
-                              @Schema(description = "동/읍/면", example = "소사본동") String city) {
+                              @Schema(description = "법정동 정보", example = "경기도 부천시 소사구 소사본1동") String city,
+                              @Schema(description = "행정동 정보", example = "경기도 부천시 소사구 소사본동") String hCity) {
 
     public static LocationInfoDto create(MogakkoLocation mogakkoLocation) {
-        return new LocationInfoDto(mogakkoLocation.getAddress(),
+        AddressInfo locationAddressInfo = mogakkoLocation.getAddressInfo();
+
+        return new LocationInfoDto(locationAddressInfo.getAddress(),
             mogakkoLocation.getLatitude(),
             mogakkoLocation.getLongitude(),
-            mogakkoLocation.getCity());
+            locationAddressInfo.getCity(),
+            locationAddressInfo.getHCity());
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/Place.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/Place.java
@@ -1,6 +1,7 @@
 package org.prgms.locomocoserver.mogakkos.dto;
 
 import org.prgms.locomocoserver.mogakkos.domain.midpoint.Midpoint;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 
 public record Place (String name,
                      String address,
@@ -12,7 +13,7 @@ public record Place (String name,
         return Midpoint.builder()
             .longitude(this.longitude)
             .latitude(this.latitude)
-            .address(address)
+            .addressInfo(AddressInfo.builder().address(address).build())
             .placeName(name)
             .build();
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/request/MogakkoCreateRequestDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation.MogakkoLocationBuilder;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 
@@ -38,11 +39,13 @@ public record MogakkoCreateRequestDto(@Schema(description = "작성자 id", exam
             return builder.build();
         }
 
+        AddressInfo addressInfo = AddressInfo.builder().address(location.address())
+            .city(location.city()).hCity(location.hCity()).build();
+
         return builder
-            .address(location.address())
+            .addressInfo(addressInfo)
             .latitude(location.latitude())
             .longitude(location.longitude())
-            .city(location.city())
             .build();
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MidpointDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/response/MidpointDto.java
@@ -11,7 +11,7 @@ public record MidpointDto(@Schema(description = "경도", example = "125.6934845
     public static MidpointDto from(Midpoint midpoint) {
         return new MidpointDto(midpoint.getLongitude(),
             midpoint.getLatitude(),
-            midpoint.getAddress(),
+            midpoint.getAddressInfo().getAddress(),
             midpoint.getPlaceName());
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/application/ChatRoomServiceTest.java
@@ -19,6 +19,7 @@ import org.prgms.locomocoserver.chat.exception.ChatErrorType;
 import org.prgms.locomocoserver.chat.exception.ChatException;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
@@ -80,7 +81,10 @@ class ChatRoomServiceTest {
                 .temperature(36.5).provider("kakao").gender(Gender.MALE).build()));
         userRepository.saveAll(dummyUsers);
 
-        MogakkoLocation mogakkoLocation = MogakkoLocation.builder().city("Carry You").address("Martin Garrix")
+        AddressInfo addressInfo = AddressInfo.builder().address("Martin Garrix").city("Carry You")
+            .build();
+
+        MogakkoLocation mogakkoLocation = MogakkoLocation.builder().addressInfo(addressInfo)
             .latitude(10.233214).longitude(23.312314).build();
         MogakkoCreateResponseDto responseDto = mogakkoService.save(
             new MogakkoCreateRequestDto(dummyUsers.get(0).getId(), "title",

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MidpointServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MidpointServiceTest.java
@@ -23,6 +23,7 @@ import org.prgms.locomocoserver.mogakkos.domain.midpoint.Midpoint;
 import org.prgms.locomocoserver.mogakkos.domain.midpoint.MidpointRepository;
 import org.prgms.locomocoserver.mogakkos.domain.participants.Participant;
 import org.prgms.locomocoserver.mogakkos.domain.participants.ParticipantRepository;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 import org.prgms.locomocoserver.mogakkos.dto.response.MidpointDto;
 import org.prgms.locomocoserver.user.domain.User;
 
@@ -54,13 +55,15 @@ class MidpointServiceTest {
         Mogakko mogakko = createMogakko(creator);
 
         int participantSize = 2;
+
         String placeName = "카페";
         String address = "서울특별시 강동구 양재대로 1369";
         String city = "서울특별시 강동구 둔촌동";
+        AddressInfo addressInfo = AddressInfo.builder().address(address).city(city).build();
 
         Midpoint midpoint = Midpoint.builder().latitude((creatorLat + userLat) / participantSize)
             .longitude((creatorLon + userLon) / participantSize).mogakko(mogakko).placeName(placeName)
-            .city(city).address(address).build();
+            .addressInfo(addressInfo).build();
 
         Participant participantCreator = Participant.builder().latitude(creatorLat).longitude(creatorLon)
             .mogakko(mogakko).user(creator).build();

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -163,10 +163,14 @@ class MogakkoServiceTest {
                 LocalDate.EPOCH).gender(Gender.MALE).temperature(36.5).provider("github").build());
 
         LocalDateTime startTime = LocalDateTime.now();
+        String city = "개봉동";
+        String hCity = "행정동";
+        String address = "주소";
+
         MogakkoCreateRequestDto mogakkoCreateRequestDto = new MogakkoCreateRequestDto(
             savedCreator.getId(),
             "제목",
-            new LocationInfoDto("주소", 20.4892, 125.2387342, "개봉동", "행정동"),
+            new LocationInfoDto(address, 20.4892, 125.2387342, city, hCity),
             startTime,
             startTime.plusHours(2),
             startTime.plusHours(1),
@@ -190,6 +194,16 @@ class MogakkoServiceTest {
         assertThat(createdMogakko.getChatRoom()).isNotNull();
 
         assertThat(mogakkoTagRepository.findAllByMogakko(createdMogakko)).hasSize(3);
+
+        Optional<MogakkoLocation> optionalMogakkoLocation = mogakkoLocationRepository.findByMogakko(
+            createdMogakko);
+        assertThat(optionalMogakkoLocation).isPresent();
+
+        MogakkoLocation mogakkoLocation = optionalMogakkoLocation.get();
+
+        assertThat(mogakkoLocation.getAddressInfo().getAddress()).isEqualTo(address);
+        assertThat(mogakkoLocation.getAddressInfo().getHCity()).isEqualTo(hCity);
+        assertThat(mogakkoLocation.getAddressInfo().getCity()).isEqualTo(city);
     }
 
     @Test
@@ -211,7 +225,8 @@ class MogakkoServiceTest {
     void success_update_mogakko_info_and_tags() {
         // given
         String updateTitle = "바뀐 제목";
-        LocationInfoDto updateLocation = new LocationInfoDto("바뀐 주소", 25.12, 110.2489, "구로동", "구로동의 행정동");
+        String updateAddress = "바뀐 주소";
+        LocationInfoDto updateLocation = new LocationInfoDto(updateAddress, 25.12, 110.2489, "구로동", "구로동의 행정동");
         String updateContent = "바뀐 내용";
 
         MogakkoUpdateRequestDto requestDto = new MogakkoUpdateRequestDto(
@@ -240,9 +255,9 @@ class MogakkoServiceTest {
 
         Optional<MogakkoLocation> locationOptional = mogakkoLocationRepository.findByMogakko(updatedMogakko);
         assertThat(locationOptional).isPresent();
+
         MogakkoLocation updatedMogakkoLocation = locationOptional.get();
-        assertThat(updatedMogakkoLocation.getAddressInfo().getAddress()).isEqualTo(updateLocation.address());
-        assertThat(updatedMogakkoLocation.getAddressInfo().getCity()).isEqualTo(updateLocation.city());
+        assertThat(updatedMogakkoLocation.getAddressInfo().getAddress()).isEqualTo(updateAddress);
         assertThat(updatedMogakkoLocation.getLatitude()).isEqualTo(updateLocation.latitude());
         assertThat(updatedMogakkoLocation.getLongitude()).isEqualTo(updateLocation.longitude());
     }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -30,6 +30,7 @@ import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
 import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
+import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
@@ -129,8 +130,11 @@ class MogakkoServiceTest {
         participantRepository.save(
             Participant.builder().user(setUpUser2).mogakko(testMogakko).build());
 
-        MogakkoLocation testMogakkoLocation = MogakkoLocation.builder().address("테스트 주소~").latitude(10.31232)
-            .longitude(105.4279823801).city("심곡본동").mogakko(testMogakko).build();
+        AddressInfo addressInfo = AddressInfo.builder().address("테스트 주소~").city("경기도 부천시 심곡본동")
+            .build();
+
+        MogakkoLocation testMogakkoLocation = MogakkoLocation.builder().addressInfo(addressInfo).latitude(10.31232)
+            .longitude(105.4279823801).mogakko(testMogakko).build();
         mogakkoLocationRepository.save(testMogakkoLocation);
 
         tagIds.addAll(List.of(js.getId(), python.getId(), codingTest.getId(), backend.getId()));
@@ -162,7 +166,7 @@ class MogakkoServiceTest {
         MogakkoCreateRequestDto mogakkoCreateRequestDto = new MogakkoCreateRequestDto(
             savedCreator.getId(),
             "제목",
-            new LocationInfoDto("주소", 20.4892, 125.2387342, "개봉동"),
+            new LocationInfoDto("주소", 20.4892, 125.2387342, "개봉동", "행정동"),
             startTime,
             startTime.plusHours(2),
             startTime.plusHours(1),
@@ -207,7 +211,7 @@ class MogakkoServiceTest {
     void success_update_mogakko_info_and_tags() {
         // given
         String updateTitle = "바뀐 제목";
-        LocationInfoDto updateLocation = new LocationInfoDto("바뀐 주소", 25.12, 110.2489, "구로동");
+        LocationInfoDto updateLocation = new LocationInfoDto("바뀐 주소", 25.12, 110.2489, "구로동", "구로동의 행정동");
         String updateContent = "바뀐 내용";
 
         MogakkoUpdateRequestDto requestDto = new MogakkoUpdateRequestDto(
@@ -237,8 +241,8 @@ class MogakkoServiceTest {
         Optional<MogakkoLocation> locationOptional = mogakkoLocationRepository.findByMogakko(updatedMogakko);
         assertThat(locationOptional).isPresent();
         MogakkoLocation updatedMogakkoLocation = locationOptional.get();
-        assertThat(updatedMogakkoLocation.getAddress()).isEqualTo(updateLocation.address());
-        assertThat(updatedMogakkoLocation.getCity()).isEqualTo(updateLocation.city());
+        assertThat(updatedMogakkoLocation.getAddressInfo().getAddress()).isEqualTo(updateLocation.address());
+        assertThat(updatedMogakkoLocation.getAddressInfo().getCity()).isEqualTo(updateLocation.city());
         assertThat(updatedMogakkoLocation.getLatitude()).isEqualTo(updateLocation.latitude());
         assertThat(updatedMogakkoLocation.getLongitude()).isEqualTo(updateLocation.longitude());
     }
@@ -299,7 +303,7 @@ class MogakkoServiceTest {
         MogakkoCreateRequestDto createRequestDto = new MogakkoCreateRequestDto(
             setUpUser2.getId(),
             "곧 삭제될 모각코",
-            new LocationInfoDto("주소1", 10.4892, 115.2387342, "가리봉동"),
+            new LocationInfoDto("주소1", 10.4892, 115.2387342, "가리봉동", "가리봉동의 행정동"),
             startTime,
             startTime.plusHours(2),
             startTime.plusHours(1),
@@ -345,7 +349,7 @@ class MogakkoServiceTest {
         MogakkoCreateRequestDto deletedUserCreateRequestDto = new MogakkoCreateRequestDto(
             setUpUser2.getId(),
             "제목1",
-            new LocationInfoDto("주소1", 10.4892, 115.2387342, "가리봉동"),
+            new LocationInfoDto("주소1", 10.4892, 115.2387342, "가리봉동", "가리봉동의 행정동"),
             startTime,
             startTime.plusHours(2),
             startTime.plusHours(1),
@@ -355,7 +359,7 @@ class MogakkoServiceTest {
         MogakkoCreateRequestDto nonExistentUserCreateRequestDto = new MogakkoCreateRequestDto(
             nonExistentId,
             "제목2",
-            new LocationInfoDto("주소2", 40.492, 117.238, "동동이"),
+            new LocationInfoDto("주소2", 40.492, 117.238, "법동이", "행동이"),
             startTime,
             startTime.plusHours(2),
             startTime.plusHours(1),
@@ -375,7 +379,7 @@ class MogakkoServiceTest {
     void fail_update_mogakko_given_not_same_creator() {
         // given
         String updateTitle = "바뀐 제목";
-        LocationInfoDto updateLocation = new LocationInfoDto("바뀐 주소", 25.12, 110.2489, "구로동");
+        LocationInfoDto updateLocation = new LocationInfoDto("바뀐 주소", 25.12, 110.2489, "구로동", "신로동");
 
         MogakkoUpdateRequestDto requestDto = new MogakkoUpdateRequestDto(
             setUpUser2.getId(), updateTitle, updateLocation,

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
@@ -61,10 +61,10 @@ class MogakkoControllerTest {
 
         MogakkoSimpleInfoResponseDto responseDto1 = new MogakkoSimpleInfoResponseDto(1L, "임시1",
             200L, 2, LocalDateTime.now(), LocalDateTime.now(), 5, 3,
-            new LocationInfoDto("주소1", 26.2442123d, 128.3422352d, "도시1"), List.copyOf(tags));
+            new LocationInfoDto("주소1", 26.2442123d, 128.3422352d, "도시1", "행정동1"), List.copyOf(tags));
         MogakkoSimpleInfoResponseDto responseDto2 = new MogakkoSimpleInfoResponseDto(2L, "임시2",
             1200L, 22, LocalDateTime.now(), LocalDateTime.now(), 10, 4,
-            new LocationInfoDto("주소2", 26.2642123d, 128.3622352d, "도시1"), List.copyOf(tags));
+            new LocationInfoDto("주소2", 26.2642123d, 128.3622352d, "도시1", "행정동2"), List.copyOf(tags));
 
         when(mogakkoService.findAllByFilter(tags, CURSOR, search, searchType, PAGE_SIZE))
             .thenReturn(List.of(responseDto1, responseDto2));
@@ -94,7 +94,7 @@ class MogakkoControllerTest {
     void success_create_mogakko() throws Exception {
         // given
         MogakkoCreateRequestDto requestDto = new MogakkoCreateRequestDto(1L, "타이틀",
-            new LocationInfoDto("주소1", 27.252453d, 127.5453234d, "도시1"), LocalDateTime.now(),
+            new LocationInfoDto("주소1", 27.252453d, 127.5453234d, "도시1", "행정동1"), LocalDateTime.now(),
             LocalDateTime.now(), LocalDateTime.now(), 10, "내용", List.of(1L, 2L));
 
         when(mogakkoService.save(requestDto)).thenReturn(new MogakkoCreateResponseDto(10L));
@@ -117,7 +117,7 @@ class MogakkoControllerTest {
 
         UserBriefInfoDto creatorInfo = new UserBriefInfoDto(creatorId, "이름1", new ImageDto(2L, "path"));
         List<MogakkoParticipantDto> participants = List.of(new MogakkoParticipantDto(10L, "이름2", null));
-        LocationInfoDto locationInfo = new LocationInfoDto("주소1", 27.2342342d, 126.142332d, "도시1");
+        LocationInfoDto locationInfo = new LocationInfoDto("주소1", 27.2342342d, 126.142332d, "도시1", "행정동1");
         MogakkoInfoDto mogakkoInfo = new MogakkoInfoDto(mogakkoId, "제목1", "내용1", 10, LocalDateTime.now(),
             LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now(),
             locationInfo, 10, 10, List.of(1L, 2L));


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #222 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- 모각코 생성, 수정 시에 행정동 정보도 이제 받아서 처리가 가능합니다.
- 마찬가지로 모각코들을 리스트로 반환할 때, 디테일 페이지를 반환할 때도 행정동 정보가 넘어옵니다.
- 주소 정보들(address, city, hCity)을 모아서 `AddressInfo` VO로 분리했습니다. 

![스크린샷 2024-08-04 183310](https://github.com/user-attachments/assets/aa458eee-cc61-4f47-949b-d48d52d18cea)

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
VO 도입으로 인한 부작용이 있는지 확인해 주세요! 그 외 코드라도 코멘트 남기실 부분이 있다면 남겨 주세요.