### PR TITLE
Feat 226 모각코 검색 필터링 or로 변경

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -107,12 +107,11 @@ public class MogakkoService {
         List<Mogakko> searchedMogakkos = search(searchVal, tagIds, pageSize, cursorDto, searchPolicy);
 
         List<MogakkoLocation> mogakkoLocations = mogakkoLocationRepository.findAllByMogakkos(searchedMogakkos);
-        Map<Long, Long> mogakkoLocationMap = new HashMap<>();
-        mogakkoLocations.forEach(location -> mogakkoLocationMap.put(location.getMogakko().getId(), location.getId()));
+        Map<Long, MogakkoLocation> mogakkoLocationMap = new HashMap<>();
+        mogakkoLocations.forEach(location -> mogakkoLocationMap.put(location.getMogakko().getId(), location));
 
         return searchedMogakkos.stream().map(mogakko -> {
-            MogakkoLocation mogakkoLocation = mogakkoLocationRepository.findById(mogakkoLocationMap.get(mogakko.getId()))
-                .orElseThrow(RuntimeException::new); // TODO: 장소 에러 반환
+            MogakkoLocation mogakkoLocation = mogakkoLocationMap.getOrDefault(mogakko.getId(), null);
             return MogakkoSimpleInfoResponseDto.create(mogakko, mogakkoLocation);
         }).toList();
     }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -1,5 +1,6 @@
 package org.prgms.locomocoserver.mogakkos.application;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,16 +9,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.prgms.locomocoserver.chat.application.ChatRoomService;
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.chat.dto.request.ChatCreateRequestDto;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.LocationSearchPolicy;
+import org.prgms.locomocoserver.mogakkos.application.searchpolicy.TitleAndContentSearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTag;
 import org.prgms.locomocoserver.mogakkos.domain.mogakkotags.MogakkoTagRepository;
-import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.ParticipationRequestDto;
@@ -43,7 +46,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class MogakkoService {
     private final MogakkoFindDetailService mogakkoFindDetailService;
-    //private final PlatformTransactionManager transactionManager;
     private final MogakkoRepository mogakkoRepository;
     private final TagRepository tagRepository;
     private final UserRepository userRepository;
@@ -52,6 +54,8 @@ public class MogakkoService {
     private final MogakkoTagRepository mogakkoTagRepository;
     private final ChatRoomService chatRoomService;
     private final MogakkoParticipationService mogakkoParticipationService;
+    private final LocationSearchPolicy locationSearchPolicy;
+    private final TitleAndContentSearchPolicy titleAndContentSearchPolicy;
 
     @Transactional
     public MogakkoCreateResponseDto save(MogakkoCreateRequestDto requestDto) {
@@ -95,14 +99,12 @@ public class MogakkoService {
     }
 
     @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, Long cursor,
-        String searchVal, SearchType searchType, int pageSize) {
-        SearchPolicy searchPolicy = searchType.getSearchPolicy(new SearchRepositoryDto(mogakkoRepository));
-        List<Mogakko> searchedMogakkos;
+    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, String searchVal, SearchType searchType, int pageSize, CursorDto cursorDto) {
+        SearchPolicy searchPolicy = getSearchPolicy(searchType);
 
         validateFilter(searchVal);
 
-        searchedMogakkos = search(tagIds, cursor, searchVal, pageSize, searchPolicy);
+        List<Mogakko> searchedMogakkos = search(searchVal, tagIds, pageSize, cursorDto, searchPolicy);
 
         List<MogakkoLocation> mogakkoLocations = mogakkoLocationRepository.findAllByMogakkos(searchedMogakkos);
         Map<Long, Long> mogakkoLocationMap = new HashMap<>();
@@ -149,25 +151,6 @@ public class MogakkoService {
         }
     }
 
-    /*private void increaseViews(Mogakko foundMogakko) {
-        // foundMogakko.increaseViews();
-
-        TransactionStatus status = transactionManager.getTransaction(
-            new DefaultTransactionDefinition());
-
-        try {
-            mogakkoRepository.increaseViews(foundMogakko);
-            transactionManager.commit(status);
-        }
-        catch (Exception e){
-            transactionManager.rollback(status);
-
-            log.error("조회 수 처리 중 에러 발생");
-            throw e;
-        }
-
-    }*/
-
     private static MogakkoDetailResponseDto getMogakkoDetailResponseDto(User creator,
         List<User> participants, List<MogakkoTag> mogakkoTags, Mogakko foundMogakko,
         MogakkoLocation foundMogakkoLocation) {
@@ -181,6 +164,13 @@ public class MogakkoService {
             LocationInfoDto.create(foundMogakkoLocation), tagIds);
 
         return new MogakkoDetailResponseDto(creatorInfoDto, mogakkoParticipantDtos, mogakkoInfoDto);
+    }
+
+    private SearchPolicy getSearchPolicy(SearchType searchType) {
+        return switch (searchType) {
+            case TITLE_CONTENT -> titleAndContentSearchPolicy;
+            case LOCATION -> locationSearchPolicy;
+        };
     }
 
     private void updateMogakkoTags(Mogakko updateMogakko, List<Long> updateTagIds) {
@@ -203,10 +193,10 @@ public class MogakkoService {
         });
 
         tagMap.forEach((tag, status) -> {
-            switch (status) {
-                case DELETE_TAG -> mogakkoTagRepository.deleteByTagAndMogakko(tag, updateMogakko);
-                case INSERT_TAG -> mogakkoTagRepository.save(
-                    MogakkoTag.builder().mogakko(updateMogakko).tag(tag).build());
+            if (status == DELETE_TAG) {
+                mogakkoTagRepository.deleteByTagAndMogakko(tag, updateMogakko);
+            } else if (status == INSERT_TAG) {
+                mogakkoTagRepository.save(MogakkoTag.builder().mogakko(updateMogakko).tag(tag).build());
             }
         });
     }
@@ -243,14 +233,9 @@ public class MogakkoService {
         }
     }
 
-    private List<Mogakko> search(List<Long> tagIds, Long cursor, String searchVal,
-        int pageSize, SearchPolicy searchPolicy) {
-        List<Mogakko> searchedMogakkos;
-        if (tagIds == null || tagIds.isEmpty()) {
-            searchedMogakkos = searchPolicy.search(cursor, searchVal, pageSize);
-        } else {
-            searchedMogakkos = searchPolicy.search(cursor, searchVal, tagIds, pageSize);
-        }
-        return searchedMogakkos;
+    private List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize,
+        CursorDto cursorDto, SearchPolicy searchPolicy) {
+
+        return searchPolicy.search(searchVal, tagIds, pageSize, LocalDateTime.now(), cursorDto);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
@@ -1,22 +1,5 @@
 package org.prgms.locomocoserver.mogakkos.application;
 
-import java.util.function.Function;
-import org.prgms.locomocoserver.mogakkos.application.searchpolicy.LocationSearchPolicy;
-import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
-import org.prgms.locomocoserver.mogakkos.application.searchpolicy.TotalSearchPolicy;
-import org.prgms.locomocoserver.mogakkos.dto.SearchRepositoryDto;
-
 public enum SearchType {
-    TOTAL(dto -> new TotalSearchPolicy(dto.mogakkoRepository())),
-    LOCATION(dto -> new LocationSearchPolicy(dto.mogakkoRepository()));
-
-    private final Function<SearchRepositoryDto, SearchPolicy> searchPolicy;
-
-    SearchType(Function<SearchRepositoryDto, SearchPolicy> searchPolicy) {
-        this.searchPolicy = searchPolicy;
-    }
-
-    public SearchPolicy getSearchPolicy(SearchRepositoryDto dto) {
-        return searchPolicy.apply(dto);
-    }
+    TOTAL, LOCATION;
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/SearchType.java
@@ -1,5 +1,5 @@
 package org.prgms.locomocoserver.mogakkos.application;
 
 public enum SearchType {
-    TOTAL, LOCATION;
+    TITLE_CONTENT, LOCATION;
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
+import org.springframework.stereotype.Component;
 
+@Component
 public class LocationSearchPolicy implements SearchPolicy {
 
     private final MogakkoRepository mogakkoRepository;

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 
 public class LocationSearchPolicy implements SearchPolicy {
 
@@ -14,12 +15,10 @@ public class LocationSearchPolicy implements SearchPolicy {
     }
 
     @Override
-    public List<Mogakko> search(Long cursor, String searchVal, int pageSize) {
-        return mogakkoRepository.findAllByCity(cursor, searchVal, pageSize, LocalDateTime.now());
-    }
+    public List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize,
+        LocalDateTime searchTime, CursorDto cursorDto) {
 
-    @Override
-    public List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds, int pageSize) {
-        return mogakkoRepository.findAllByCity(tagIds, tagIds.size(), cursor, searchVal, pageSize, LocalDateTime.now());
+        return mogakkoRepository.findAllByCity(tagIds, searchVal, pageSize, searchTime,
+            cursorDto.countCursor(), cursorDto.timeCursor(), cursorDto.idCursor());
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
@@ -1,9 +1,10 @@
 package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 
 public interface SearchPolicy {
-    List<Mogakko> search(Long cursor, String searchVal, int pageSize);
-    List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds, int pageSize);
+    List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, CursorDto cursorDto);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
@@ -8,11 +8,11 @@ import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TotalSearchPolicy implements SearchPolicy {
+public class TitleAndContentSearchPolicy implements SearchPolicy {
 
     private final MogakkoRepository mogakkoRepository;
 
-    public TotalSearchPolicy(MogakkoRepository mogakkoRepository) {
+    public TitleAndContentSearchPolicy(MogakkoRepository mogakkoRepository) {
         this.mogakkoRepository = mogakkoRepository;
     }
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
 import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
+import org.springframework.stereotype.Component;
 
+@Component
 public class TotalSearchPolicy implements SearchPolicy {
 
     private final MogakkoRepository mogakkoRepository;

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TotalSearchPolicy.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 
 public class TotalSearchPolicy implements SearchPolicy {
 
@@ -14,12 +15,9 @@ public class TotalSearchPolicy implements SearchPolicy {
     }
 
     @Override
-    public List<Mogakko> search(Long cursor, String searchVal, int pageSize) {
-        return mogakkoRepository.findAllByFilter(cursor, searchVal, pageSize, LocalDateTime.now());
-    }
+    public List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, CursorDto cursorDto) {
 
-    @Override
-    public List<Mogakko> search(Long cursor, String searchVal, List<Long> tagIds, int pageSize) {
-        return mogakkoRepository.findAllByFilter(cursor, searchVal, tagIds, tagIds.size(), pageSize, LocalDateTime.now());
+        return mogakkoRepository.findAllByTitleAndContent(searchVal, tagIds, pageSize, searchTime,
+            cursorDto.countCursor(), cursorDto.timeCursor(), cursorDto.idCursor());
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
 
@@ -19,46 +18,40 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query("SELECT m FROM Mogakko m WHERE m.id = :id AND m.deletedAt IS NULL")
     Optional<Mogakko> findByIdAndDeletedAtIsNullForUpdate(Long id); // 이 코드는 추후 따로 클래스 분리를 할 수도 있음
 
-    @Query(value = "SELECT m.* FROM mogakko m "
-        + "JOIN locations l ON (m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND l.mogakko_id = m.id) "
-        + "WHERE MATCH(l.city) AGAINST(CONCAT('\"', :city, '\"') IN BOOLEAN MODE) "
-        + "ORDER BY m.created_at DESC "
-        + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByCity(Long cursor, String city, int pageSize, LocalDateTime now);
-
     @Query(value = "SELECT m.* "
-        + "FROM mogakko_tags mt "
-        + "INNER JOIN mogakko m ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.id = mt.mogakko_id "
-        + "INNER JOIN locations l ON l.mogakko_id = m.id "
-        + "WHERE mt.tag_id IN :tagIds AND MATCH(l.city) AGAINST(CONCAT('\"', :city, '\"') IN BOOLEAN MODE) "
-        + "GROUP BY mt.mogakko_id HAVING COUNT(mt.mogakko_id) = :tagSize "
-        + "ORDER BY m.created_at DESC "
+        + "FROM mogakko m "
+        + "INNER JOIN locations l ON l.mogakko_id = m.id AND m.deadline > :searchTime "
+            + "AND m.deleted_at IS NULL AND (MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) OR MATCH(l.h_city) AGAINST(:city IN BOOLEAN MODE)) "
+        + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
+        + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
+        + "ORDER BY COUNT(mt.id) DESC, m.created_at DESC "
         + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByCity(Iterable<Long> tagIds, int tagSize, Long cursor, String city, int pageSize, LocalDateTime now);
+    List<Mogakko> findAllByCity(Iterable<Long> tagIds, String city, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId); // 장소
 
     @Query(value = "SELECT m.* FROM mogakko m "
-        + "INNER JOIN users u ON m.id < :cursor AND m.deleted_at IS NULL AND m.deadline > :now AND m.creator_id = u.id "
+        + "INNER JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime AND m.creator_id = u.id "
+            + "AND (MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE)) "
         + "INNER JOIN locations l ON l.mogakko_id = m.id "
-        + "INNER JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
-        + "WHERE MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE) OR u.nickname LIKE :searchVal% OR MATCH(l.city) AGAINST(:searchVal IN BOOLEAN MODE) "
-        + "GROUP BY m.id HAVING count(m.id) = :tagSize "
-        + "ORDER BY m.created_at DESC "
+        + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
+        + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
+        + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "
         + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByFilter(Long cursor, String searchVal, List<Long> tagIds, int tagSize, int pageSize, LocalDateTime now);
+    List<Mogakko> findAllByTitleAndContent(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId); // 제목 + 내용
 
     @Query(value = "SELECT m.* FROM mogakko m "
-        + "INNER JOIN users u ON m.id < :cursor AND m.deadline > :now AND m.deleted_at IS NULL AND m.creator_id = u.id "
-        + "INNER JOIN locations l ON l.mogakko_id = m.id "
-        + "WHERE MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE) OR u.nickname LIKE :searchVal% OR MATCH(l.city) AGAINST(:searchVal IN BOOLEAN MODE) "
-        + "ORDER BY m.created_at DESC "
+        + "JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime "
+            + "AND MATCH(u.nickname) AGAINST(:searchVal IN BOOLEAN MODE) AND m.creator_id = u.id "
+        + "LEFT JOIN mogakko_tags mt ON mt.mogakko_id = m.id AND mt.tag_id IN :tagIds "
+        + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
+        + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "
         + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByFilter(Long cursor, String searchVal, int pageSize, LocalDateTime now);
+    List<Mogakko> findAllByUserNickname(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId);
 
-    @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime >= :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
-    List<Mogakko> findOngoingMogakkosByUser(@Param("user") User user, @Param("now") LocalDateTime now);
+    @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime >= :searchTime AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
+    List<Mogakko> findOngoingMogakkosByUser(User user, LocalDateTime searchTime);
 
-    @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime < :now AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
-    List<Mogakko> findCompletedMogakkosByUser(@Param("user") User user, @Param("now") LocalDateTime now);
+    @Query("SELECT m FROM Mogakko m JOIN m.participants p WHERE p.user = :user AND m.endTime < :searchTime AND m.deletedAt IS NULL AND p.user.deletedAt IS NULL")
+    List<Mogakko> findCompletedMogakkosByUser(User user, LocalDateTime searchTime);
 
     @Modifying
     @Query("UPDATE Mogakko m SET m.views = m.views + 1 WHERE m = :mogakko")

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -20,7 +20,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
 
     @Query(value = "SELECT m.* "
         + "FROM mogakko m "
-        + "INNER JOIN locations l ON l.mogakko_id = m.id AND m.deadline > :searchTime "
+        + "JOIN locations l ON l.mogakko_id = m.id AND m.deadline > :searchTime "
             + "AND m.deleted_at IS NULL AND (MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) OR MATCH(l.h_city) AGAINST(:city IN BOOLEAN MODE)) "
         + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
         + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
@@ -31,7 +31,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query(value = "SELECT m.* FROM mogakko m "
         + "INNER JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime AND m.creator_id = u.id "
             + "AND (MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE)) "
-        + "INNER JOIN locations l ON l.mogakko_id = m.id "
+        + "LEFT JOIN locations l ON l.mogakko_id = m.id "
         + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
         + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
         + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -29,10 +29,10 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     List<Mogakko> findAllByCity(Iterable<Long> tagIds, String city, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId); // 장소
 
     @Query(value = "SELECT m.* FROM mogakko m "
-        + "INNER JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime AND m.creator_id = u.id "
-            + "AND (MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE)) "
         + "LEFT JOIN locations l ON l.mogakko_id = m.id "
         + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
+        + "WHERE m.deleted_at IS NULL AND m.deadline > :searchTime "
+        + "       AND (MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE)) "
         + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
         + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "
         + "LIMIT :pageSize", nativeQuery = true)
@@ -40,7 +40,7 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
 
     @Query(value = "SELECT m.* FROM mogakko m "
         + "JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime "
-            + "AND MATCH(u.nickname) AGAINST(:searchVal IN BOOLEAN MODE) AND m.creator_id = u.id "
+        + "     AND MATCH(u.nickname) AGAINST(:searchVal IN BOOLEAN MODE) AND m.creator_id = u.id "
         + "LEFT JOIN mogakko_tags mt ON mt.mogakko_id = m.id AND mt.tag_id IN :tagIds "
         + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
         + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/CursorDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/CursorDto.java
@@ -1,0 +1,6 @@
+package org.prgms.locomocoserver.mogakkos.dto;
+
+import java.time.LocalDateTime;
+
+public record CursorDto(Long idCursor, Long countCursor, LocalDateTime timeCursor) {
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/LocationInfoDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/LocationInfoDto.java
@@ -11,6 +11,10 @@ public record LocationInfoDto(@Schema(description = "주소", example = "경기�
                               @Schema(description = "행정동 정보", example = "경기도 부천시 소사구 소사본동") String hCity) {
 
     public static LocationInfoDto create(MogakkoLocation mogakkoLocation) {
+        if (mogakkoLocation == null) {
+            return null;
+        }
+
         AddressInfo locationAddressInfo = mogakkoLocation.getAddressInfo();
 
         return new LocationInfoDto(locationAddressInfo.getAddress(),

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.global.common.dto.Results;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.application.SearchType;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;
@@ -34,15 +36,16 @@ public class MogakkoController {
             @ApiResponse(responseCode = "200", description = "모각코 목록 반환 성공")
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
-            @Parameter(description = "필터링 커서") @RequestParam(required = false, defaultValue = "9223372036854775807") Long cursor,
+            @Parameter(description = "id 커서") @RequestParam(required = false, defaultValue = "9223372036854775807") Long idCursor,
+            @Parameter(description = "생성 시간 커서") @RequestParam(required = false, defaultValue = "9999-12-31T23:59:59") LocalDateTime timeCursor,
+            @Parameter(description = "필터 태그 카운트 커서") @RequestParam(required = false, defaultValue = "9223372036854775807") Long countCursor,
             @Parameter(description = "검색 값") @RequestParam(name = "search", required = false, defaultValue = "") String searchVal,
             @Parameter(description = "검색 타입") @RequestParam SearchType searchType,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "100") Integer pageSize,
             @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
         searchVal = searchVal.strip();
 
-        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags,
-                cursor, searchVal, searchType, pageSize);
+        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags, searchVal, searchType, pageSize, new CursorDto(idCursor, countCursor, timeCursor));
 
         Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.global.common.dto.Results;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
@@ -44,6 +45,7 @@ public class MogakkoController {
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "100") Integer pageSize,
             @Parameter(description = "필터링 태그 id 목록") @RequestParam(required = false) List<Long> tags) {
         searchVal = searchVal.strip();
+        tags = tags == null ? new ArrayList<>() : tags;
 
         List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags, searchVal, searchType, pageSize, new CursorDto(idCursor, countCursor, timeCursor));
 

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -31,6 +31,7 @@ import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
@@ -59,7 +60,10 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @TestInstance(Lifecycle.PER_CLASS)
 class MogakkoServiceTest {
-    static final long CURSOR = Long.MAX_VALUE;
+    private static final long ID_CURSOR = Long.MAX_VALUE;
+    private static final long COUNT_CURSOR = Long.MAX_VALUE;
+    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9999, 12, 31, 23, 59);
+    private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
     static final int PAGE_SIZE = 10;
 
     @Autowired
@@ -285,22 +289,22 @@ class MogakkoServiceTest {
     }
 
     @Test
-    @DisplayName("입력된 필터링 인자들에 대해 정상적으로 전체 검색을 수행한다")
+    @DisplayName("입력된 필터링 인자들에 대해 정상적으로 제목 + 내용 검색을 수행한다")
     void success_find_all_by_filter_given_normal_args() {
         // given
         String normalSearchVal = "제곧";
         String abnormalSearchVal = "noContent";
-        SearchType searchType = SearchType.TOTAL;
+        SearchType searchType = SearchType.TITLE_CONTENT;
         List<Long> havingTagIds = mogakkoTagRepository.findAllByMogakko(testMogakko).stream()
             .map(mt -> mt.getTag().getId()).toList();
 
         // when
         List<MogakkoSimpleInfoResponseDto> filtered = mogakkoService.findAllByFilter(havingTagIds,
-            CURSOR, normalSearchVal, searchType, PAGE_SIZE);
+            normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
         List<MogakkoSimpleInfoResponseDto> filteredWithoutTagIds = mogakkoService.findAllByFilter(Collections.emptyList(),
-            CURSOR, normalSearchVal, searchType, PAGE_SIZE);
+            normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
         List<MogakkoSimpleInfoResponseDto> emptyFiltered = mogakkoService.findAllByFilter(Collections.emptyList(),
-            CURSOR, abnormalSearchVal, searchType, PAGE_SIZE);
+            abnormalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
 
         // then
         assertThat(filtered).hasSize(1);
@@ -345,8 +349,8 @@ class MogakkoServiceTest {
 
         // when, then
         assertThatThrownBy(
-            () -> mogakkoService.findAllByFilter(null, Long.MAX_VALUE, search, SearchType.TOTAL,
-                10))
+            () -> mogakkoService.findAllByFilter(null, search, SearchType.TITLE_CONTENT,
+                10, TEST_CURSOR_DTO))
             .isInstanceOf(MogakkoException.class)
             .hasFieldOrPropertyWithValue("errorType", MogakkoErrorType.TOO_LITTLE_INPUT);
     }
@@ -420,9 +424,9 @@ class MogakkoServiceTest {
 
         // when
         List<MogakkoSimpleInfoResponseDto> normalResult = mogakkoService.findAllByFilter(
-            havingTagIds, CURSOR, normalSearchVal, searchType, PAGE_SIZE);
+            havingTagIds, normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
         List<MogakkoSimpleInfoResponseDto> abnormalResult = mogakkoService.findAllByFilter(
-            havingTagIds, CURSOR, abnormalSearchVal, searchType, PAGE_SIZE);
+            havingTagIds, abnormalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
 
         // then
         assertThat(normalResult).hasSize(1);

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -59,7 +59,7 @@ import org.springframework.transaction.annotation.Transactional;
 class MogakkoServiceTest {
     private static final long ID_CURSOR = Long.MAX_VALUE;
     private static final long COUNT_CURSOR = Long.MAX_VALUE;
-    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9999, 12, 31, 23, 59);
+    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9990, 12, 31, 23, 59);
     private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
     static final int PAGE_SIZE = 10;
 

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -15,12 +15,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.prgms.locomocoserver.categories.domain.Category;
 import org.prgms.locomocoserver.categories.domain.CategoryInputType;
 import org.prgms.locomocoserver.categories.domain.CategoryRepository;
@@ -58,7 +56,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@TestInstance(Lifecycle.PER_CLASS)
 class MogakkoServiceTest {
     private static final long ID_CURSOR = Long.MAX_VALUE;
     private static final long COUNT_CURSOR = Long.MAX_VALUE;
@@ -92,7 +89,7 @@ class MogakkoServiceTest {
     private Mogakko testMogakko;
     private final List<Long> tagIds = new ArrayList<>();
 
-    @BeforeAll
+    @BeforeEach
     void setUp() {
         Category langs = Category.builder().categoryType(CategoryType.MOGAKKO).name("개발 언어")
             .categoryInputType(CategoryInputType.CHECKBOX).build();
@@ -144,7 +141,7 @@ class MogakkoServiceTest {
         tagIds.addAll(List.of(js.getId(), python.getId(), codingTest.getId(), backend.getId()));
     }
 
-    @AfterAll
+    @AfterEach
     void tearDown() {
         chatMessageRepository.deleteAll();
         participantRepository.deleteAll();
@@ -298,6 +295,12 @@ class MogakkoServiceTest {
         List<Long> havingTagIds = mogakkoTagRepository.findAllByMogakko(testMogakko).stream()
             .map(mt -> mt.getTag().getId()).toList();
 
+        Mogakko testMogakko2 = Mogakko.builder().title("title2").content("제곧내2").views(20).likeCount(10)
+            .startTime(LocalDateTime.now())
+            .endTime(LocalDateTime.now().plusHours(2)).deadline(LocalDateTime.now().plusHours(1))
+            .maxParticipants(10).creator(setUpUser1).build();
+        mogakkoRepository.save(testMogakko2);
+
         // when
         List<MogakkoSimpleInfoResponseDto> filtered = mogakkoService.findAllByFilter(havingTagIds,
             normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
@@ -307,10 +310,10 @@ class MogakkoServiceTest {
             abnormalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
 
         // then
-        assertThat(filtered).hasSize(1);
+        assertThat(filtered).hasSize(2);
         assertThat(filtered.get(0).title()).isEqualTo(testMogakko.getTitle());
-        assertThat(filteredWithoutTagIds).hasSize(1);
-        assertThat(filteredWithoutTagIds.get(0).title()).isEqualTo(testMogakko.getTitle());
+        assertThat(filteredWithoutTagIds).hasSize(2);
+        assertThat(filteredWithoutTagIds.get(0).title()).isEqualTo(testMogakko2.getTitle());
         assertThat(emptyFiltered).isEmpty();
     }
 

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
@@ -43,7 +43,7 @@ import org.springframework.util.MultiValueMap;
 class MogakkoControllerTest {
     private static final long ID_CURSOR = Long.MAX_VALUE;
     private static final long COUNT_CURSOR = Long.MAX_VALUE;
-    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9999, 12, 31, 23, 59);
+    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9990, 12, 31, 23, 59);
     private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
     private static final int PAGE_SIZE = 20;
     private static final String API_VERSION = "/api/v1";

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
@@ -18,6 +18,7 @@ import org.prgms.locomocoserver.global.filter.ExceptionHandlerFilter;
 import org.prgms.locomocoserver.image.dto.ImageDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.application.SearchType;
+import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
@@ -40,7 +41,10 @@ import org.springframework.util.MultiValueMap;
 
 @WebMvcTest(controllers = MogakkoController.class, excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { CorsFilter.class, AuthenticationFilter.class, ExceptionHandlerFilter.class, GlobalExceptionHandler.class }))
 class MogakkoControllerTest {
-    private static final long CURSOR = Long.MAX_VALUE;
+    private static final long ID_CURSOR = Long.MAX_VALUE;
+    private static final long COUNT_CURSOR = Long.MAX_VALUE;
+    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9999, 12, 31, 23, 59);
+    private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
     private static final int PAGE_SIZE = 20;
     private static final String API_VERSION = "/api/v1";
 
@@ -56,7 +60,7 @@ class MogakkoControllerTest {
     void success_find_all_mogakkos() throws Exception {
         // given
         String search = "ISD";
-        SearchType searchType = SearchType.TOTAL;
+        SearchType searchType = SearchType.TITLE_CONTENT;
         List<Long> tags = List.of(1L, 2L);
 
         MogakkoSimpleInfoResponseDto responseDto1 = new MogakkoSimpleInfoResponseDto(1L, "임시1",
@@ -66,11 +70,13 @@ class MogakkoControllerTest {
             1200L, 22, LocalDateTime.now(), LocalDateTime.now(), 10, 4,
             new LocationInfoDto("주소2", 26.2642123d, 128.3622352d, "도시1", "행정동2"), List.copyOf(tags));
 
-        when(mogakkoService.findAllByFilter(tags, CURSOR, search, searchType, PAGE_SIZE))
+        when(mogakkoService.findAllByFilter(tags, search, searchType, PAGE_SIZE, TEST_CURSOR_DTO))
             .thenReturn(List.of(responseDto1, responseDto2));
 
         MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
-        paramMap.add("cursor", String.valueOf(CURSOR));
+        paramMap.add("idCursor", String.valueOf(ID_CURSOR));
+        paramMap.add("timeCursor", String.valueOf(TIME_CURSOR));
+        paramMap.add("countCursor", String.valueOf(COUNT_CURSOR));
         paramMap.add("search", search);
         paramMap.add("searchType", searchType.name());
         paramMap.add("pageSize", String.valueOf(PAGE_SIZE));


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #226 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
모각코 검색 태그 필터링을 이제 OR로 합니다. 필터링에 제일 근접한 결과를 상단부터 볼 수 있으며 태그가 아예 안맞더라도 스크롤을 하면서 확인할 수 있습니다. 정렬 기준은 아래와 같습니다.
1. 필터링 태그 일치 개수 많은 순
2. 생성일 최근 순
3. 모각코 id

또한 커서 기반 페이지네이션을 사용함에 따라 현재 커서를 결정할 수 있는 요소가 더 필요해졌고, 위 정렬 기준에 따른, 태그 수, 생성일도 커서로 같이 받도록 컨트롤러도 수정했습니다.

1번을 기준으로 정렬하는 것이 가장 핵심이었고, 이에 따라 `mogakko`를 `mogakko_tags` 테이블과 LEFT JOIN 했습니다. 이로써 필터링 태그가 아예 없더라도 모든 모각코가 결과에 포함될 수 있습니다. 그리고 각 모각코의 태그 개수를 `COUNT()` 집계 함수로 집계해서 `ORDER BY` 절을 이용해 `COUNT()`, `created_at`, `id` 순으로 정렬시켜 주었습니다.

고민은 쿼리 실행에 있습니다. `EXPLAIN`으로 실행 계획을 보면 안 좋은 것들만 덕지덕지 붙어 있습니다. 일단 인덱스 풀 스캔을 해서 거의 테이블 풀 스캔이랑 비슷한 성능을 내며, `EXTRA`를 보면 SQL 수행 정보를 볼 수 있는데 많은 [포](https://seongonion.tistory.com/158)[스](https://m.blog.naver.com/pjt3591oo/220832178743)[팅](https://jhlee-developer.tistory.com/entry/MYSQL)에서 Using filesort와 Using temporary는 피해야 한다고 적혀있네요. 하지만 아무리 생각해도 튜닝을 어떻게 해야 할지 몰라 일단 그대로 두었습니다. 아직은 데이터가 많지는 않아서 빠르기도 하고요... 추후 고민할 문제인 것 같아요.

![image](https://github.com/user-attachments/assets/df14d33a-4c74-4aa0-97ca-becba9fb9ff4)
예시 쿼리문

![image](https://github.com/user-attachments/assets/f5cc22ed-5d77-4de9-b348-a7b6409cbdd7)
![image](https://github.com/user-attachments/assets/8091e8ba-d691-42de-abf0-012f2d36810a)
수행된 `EXPLAIN` 실행 계획

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
* 테스트 코드를 짜두기는 했으나, 쿼리문이 복잡한 만큼 수행이 제대로 되는지 한 번 더 확인해 주시면 감사하겠습니다. 엣지 케이스가 있을 수 있습니다.
* 쿼리 튜닝에 대해서도 같이 생각해주시면 감사할 것 같아요~!