### PR TITLE
Fix 238 모각코 리스트 반환 쿼리 재구현

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -99,12 +99,12 @@ public class MogakkoService {
     }
 
     @Transactional(readOnly = true)
-    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, String searchVal, SearchType searchType, int pageSize, CursorDto cursorDto) {
+    public List<MogakkoSimpleInfoResponseDto> findAllByFilter(List<Long> tagIds, String searchVal, SearchType searchType, int pageSize, Long offset) {
         SearchPolicy searchPolicy = getSearchPolicy(searchType);
 
         validateFilter(searchVal);
 
-        List<Mogakko> searchedMogakkos = search(searchVal, tagIds, pageSize, cursorDto, searchPolicy);
+        List<Mogakko> searchedMogakkos = search(searchVal, tagIds, pageSize, offset, searchPolicy);
 
         List<MogakkoLocation> mogakkoLocations = mogakkoLocationRepository.findAllByMogakkos(searchedMogakkos);
         Map<Long, MogakkoLocation> mogakkoLocationMap = new HashMap<>();
@@ -233,8 +233,8 @@ public class MogakkoService {
     }
 
     private List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize,
-        CursorDto cursorDto, SearchPolicy searchPolicy) {
+        Long offset, SearchPolicy searchPolicy) {
 
-        return searchPolicy.search(searchVal, tagIds, pageSize, LocalDateTime.now(), cursorDto);
+        return searchPolicy.search(searchVal, tagIds, pageSize, LocalDateTime.now(), offset);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -14,7 +14,6 @@ import org.prgms.locomocoserver.mogakkos.application.searchpolicy.TitleAndConten
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.application.searchpolicy.SearchPolicy;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/LocationSearchPolicy.java
@@ -18,9 +18,8 @@ public class LocationSearchPolicy implements SearchPolicy {
 
     @Override
     public List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize,
-        LocalDateTime searchTime, CursorDto cursorDto) {
+        LocalDateTime searchTime, Long offset) {
 
-        return mogakkoRepository.findAllByCity(tagIds, searchVal, pageSize, searchTime,
-            cursorDto.countCursor(), cursorDto.timeCursor(), cursorDto.idCursor());
+        return mogakkoRepository.findAllByCity(tagIds, searchVal, pageSize, searchTime, offset);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
@@ -6,5 +6,5 @@ import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 
 public interface SearchPolicy {
-    List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, CursorDto cursorDto);
+    List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long offset);
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/SearchPolicy.java
@@ -3,7 +3,6 @@ package org.prgms.locomocoserver.mogakkos.application.searchpolicy;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 
 public interface SearchPolicy {
     List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long offset);

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
@@ -17,9 +17,8 @@ public class TitleAndContentSearchPolicy implements SearchPolicy {
     }
 
     @Override
-    public List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, CursorDto cursorDto) {
+    public List<Mogakko> search(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long offset) {
 
-        return mogakkoRepository.findAllByTitleAndContent(searchVal, tagIds, pageSize, searchTime,
-            cursorDto.countCursor(), cursorDto.timeCursor(), cursorDto.idCursor());
+        return mogakkoRepository.findAllByTitleAndContent(searchVal, tagIds, pageSize, searchTime, offset);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/searchpolicy/TitleAndContentSearchPolicy.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/domain/MogakkoRepository.java
@@ -21,22 +21,22 @@ public interface MogakkoRepository extends JpaRepository<Mogakko, Long> {
     @Query(value = "SELECT m.* "
         + "FROM mogakko m "
         + "JOIN locations l ON l.mogakko_id = m.id AND m.deadline > :searchTime "
-            + "AND m.deleted_at IS NULL AND (MATCH(l.city) AGAINST(:city IN BOOLEAN MODE) OR MATCH(l.h_city) AGAINST(:city IN BOOLEAN MODE)) "
+            + "AND m.deleted_at IS NULL AND (l.city LIKE CONCAT(:city, '%') OR l.h_city LIKE CONCAT(:city, '%')) "
         + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
-        + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
+        + "GROUP BY m.id "
         + "ORDER BY COUNT(mt.id) DESC, m.created_at DESC "
-        + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByCity(Iterable<Long> tagIds, String city, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId); // 장소
+        + "LIMIT :pageSize OFFSET :offset", nativeQuery = true)
+    List<Mogakko> findAllByCity(Iterable<Long> tagIds, String city, int pageSize, LocalDateTime searchTime, Long offset); // 장소
 
     @Query(value = "SELECT m.* FROM mogakko m "
         + "LEFT JOIN locations l ON l.mogakko_id = m.id "
         + "LEFT JOIN mogakko_tags mt ON mt.tag_id IN :tagIds AND mt.mogakko_id = m.id "
         + "WHERE m.deleted_at IS NULL AND m.deadline > :searchTime "
         + "       AND (:searchVal = '' OR MATCH(m.title) AGAINST(:searchVal IN BOOLEAN MODE) OR MATCH(m.content) AGAINST(:searchVal IN BOOLEAN MODE)) "
-        + "GROUP BY m.id HAVING (COUNT(mt.id) = :countCursor AND m.created_at <= :timeCursor AND m.id < :cursorId) OR COUNT(mt.id) < :countCursor "
-        + "ORDER BY COUNT(m.id) DESC, m.created_at DESC, m.id DESC "
-        + "LIMIT :pageSize", nativeQuery = true)
-    List<Mogakko> findAllByTitleAndContent(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long countCursor, LocalDateTime timeCursor, Long cursorId); // 제목 + 내용
+        + "GROUP BY m.id "
+        + "ORDER BY COUNT(mt.id) DESC, m.created_at DESC, m.id DESC "
+        + "LIMIT :pageSize OFFSET :offset", nativeQuery = true)
+    List<Mogakko> findAllByTitleAndContent(String searchVal, List<Long> tagIds, int pageSize, LocalDateTime searchTime, Long offset); // 제목 + 내용
 
     @Query(value = "SELECT m.* FROM mogakko m "
         + "JOIN users u ON m.deleted_at IS NULL AND m.deadline > :searchTime "

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/dto/CursorDto.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/dto/CursorDto.java
@@ -1,6 +1,0 @@
-package org.prgms.locomocoserver.mogakkos.dto;
-
-import java.time.LocalDateTime;
-
-public record CursorDto(Long idCursor, Long countCursor, LocalDateTime timeCursor) {
-}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -37,9 +37,7 @@ public class MogakkoController {
             @ApiResponse(responseCode = "200", description = "모각코 목록 반환 성공")
     )
     public ResponseEntity<Results<MogakkoSimpleInfoResponseDto>> findAll(
-            @Parameter(description = "id 커서") @RequestParam(required = false, defaultValue = "9223372036854775807") Long idCursor,
-            @Parameter(description = "생성 시간 커서") @RequestParam(required = false, defaultValue = "9999-12-31T23:59:59") LocalDateTime timeCursor,
-            @Parameter(description = "필터 태그 카운트 커서") @RequestParam(required = false, defaultValue = "9223372036854775807") Long countCursor,
+            @Parameter(description = "검색 오프셋") @RequestParam(required = false, defaultValue = "0") Long offset,
             @Parameter(description = "검색 값") @RequestParam(name = "search", required = false, defaultValue = "") String searchVal,
             @Parameter(description = "검색 타입") @RequestParam SearchType searchType,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "100") Integer pageSize,
@@ -47,7 +45,7 @@ public class MogakkoController {
         searchVal = searchVal.strip();
         tags = tags == null ? new ArrayList<>() : tags;
 
-        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags, searchVal, searchType, pageSize, new CursorDto(idCursor, countCursor, timeCursor));
+        List<MogakkoSimpleInfoResponseDto> responseDtos = mogakkoService.findAllByFilter(tags, searchVal, searchType, pageSize, offset);
 
         Results<MogakkoSimpleInfoResponseDto> results = new Results<>(responseDtos);
 

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoController.java
@@ -5,13 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.LocalDateTime;
+
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.prgms.locomocoserver.global.common.dto.Results;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.application.SearchType;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.response.MogakkoCreateResponseDto;

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -56,8 +56,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class MogakkoServiceTest {
-    private static final long OFFSET = 0L;
-    static final int PAGE_SIZE = 10;
+    private static final long GLOBAL_OFFSET = 0L;
+    static final int GLOBAL_PAGE_SIZE = 10;
 
     @Autowired
     private MogakkoService mogakkoService;
@@ -285,6 +285,7 @@ class MogakkoServiceTest {
     @DisplayName("입력된 필터링 인자들에 대해 정상적으로 제목 + 내용 검색을 수행한다")
     void success_find_all_by_filter_given_normal_args() {
         // given
+        int pageSize = 1;
         String normalSearchVal = "제곧";
         String abnormalSearchVal = "noContent";
         SearchType searchType = SearchType.TITLE_CONTENT;
@@ -298,16 +299,20 @@ class MogakkoServiceTest {
         mogakkoRepository.save(testMogakko2);
 
         // when
-        List<MogakkoSimpleInfoResponseDto> filtered = mogakkoService.findAllByFilter(havingTagIds,
-            normalSearchVal, searchType, PAGE_SIZE, OFFSET);
+        List<MogakkoSimpleInfoResponseDto> filtered1Page = mogakkoService.findAllByFilter(havingTagIds,
+            normalSearchVal, searchType, pageSize, GLOBAL_OFFSET);
+        List<MogakkoSimpleInfoResponseDto> filtered2Page = mogakkoService.findAllByFilter(havingTagIds,
+            normalSearchVal, searchType, pageSize, GLOBAL_OFFSET + 1);
         List<MogakkoSimpleInfoResponseDto> filteredWithoutTagIds = mogakkoService.findAllByFilter(Collections.emptyList(),
-            normalSearchVal, searchType, PAGE_SIZE, OFFSET);
+            normalSearchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
         List<MogakkoSimpleInfoResponseDto> emptyFiltered = mogakkoService.findAllByFilter(Collections.emptyList(),
-            abnormalSearchVal, searchType, PAGE_SIZE, OFFSET);
+            abnormalSearchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
 
         // then
-        assertThat(filtered).hasSize(2);
-        assertThat(filtered.get(0).title()).isEqualTo(testMogakko.getTitle());
+        assertThat(filtered1Page).hasSize(1);
+        assertThat(filtered1Page.get(0).title()).isEqualTo(testMogakko.getTitle());
+        assertThat(filtered2Page).hasSize(1);
+        assertThat(filtered2Page.get(0).title()).isEqualTo(testMogakko2.getTitle());
         assertThat(filteredWithoutTagIds).hasSize(2);
         assertThat(filteredWithoutTagIds.get(0).title()).isEqualTo(testMogakko2.getTitle());
         assertThat(emptyFiltered).isEmpty();
@@ -321,7 +326,7 @@ class MogakkoServiceTest {
         SearchType searchType = SearchType.TITLE_CONTENT;
 
         // when
-        List<MogakkoSimpleInfoResponseDto> allByFilter = mogakkoService.findAllByFilter(new ArrayList<>(), searchVal, searchType, PAGE_SIZE, OFFSET);
+        List<MogakkoSimpleInfoResponseDto> allByFilter = mogakkoService.findAllByFilter(new ArrayList<>(), searchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
 
         // then
         assertThat(allByFilter).isNotEmpty();
@@ -364,7 +369,7 @@ class MogakkoServiceTest {
         // when, then
         assertThatThrownBy(
             () -> mogakkoService.findAllByFilter(null, search, SearchType.TITLE_CONTENT,
-                10, OFFSET))
+                10, GLOBAL_OFFSET))
             .isInstanceOf(MogakkoException.class)
             .hasFieldOrPropertyWithValue("errorType", MogakkoErrorType.TOO_LITTLE_INPUT);
     }
@@ -439,11 +444,11 @@ class MogakkoServiceTest {
 
         // when
         List<MogakkoSimpleInfoResponseDto> normalCityResult = mogakkoService.findAllByFilter(
-                havingTagIds, normalCitySearchVal, searchType, PAGE_SIZE, OFFSET);
+                havingTagIds, normalCitySearchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
         List<MogakkoSimpleInfoResponseDto> normalHCityResult = mogakkoService.findAllByFilter(
-                new ArrayList<>(), normalHCitySearchVal, searchType, PAGE_SIZE, OFFSET);
+                new ArrayList<>(), normalHCitySearchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
         List<MogakkoSimpleInfoResponseDto> abnormalResult = mogakkoService.findAllByFilter(
-                havingTagIds, abnormalSearchVal, searchType, PAGE_SIZE, OFFSET);
+                havingTagIds, abnormalSearchVal, searchType, GLOBAL_PAGE_SIZE, GLOBAL_OFFSET);
 
         // then
         assertThat(normalCityResult).hasSize(1);

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -57,10 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 class MogakkoServiceTest {
-    private static final long ID_CURSOR = Long.MAX_VALUE;
-    private static final long COUNT_CURSOR = Long.MAX_VALUE;
-    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9990, 12, 31, 23, 59);
-    private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
+    private static final long OFFSET = 0L;
     static final int PAGE_SIZE = 10;
 
     @Autowired
@@ -131,8 +128,8 @@ class MogakkoServiceTest {
         participantRepository.save(
             Participant.builder().user(setUpUser2).mogakko(testMogakko).build());
 
-        AddressInfo addressInfo = AddressInfo.builder().address("테스트 주소~").city("경기도 부천시 심곡본동")
-            .build();
+        AddressInfo addressInfo = AddressInfo.builder().address("테스트 주소~").city("경기도 부천시 소사구 심곡본동")
+                .hCity("경기도 부천시 원미구 심곡1동").build();
 
         MogakkoLocation testMogakkoLocation = MogakkoLocation.builder().addressInfo(addressInfo).latitude(10.31232)
             .longitude(105.4279823801).mogakko(testMogakko).build();
@@ -303,11 +300,11 @@ class MogakkoServiceTest {
 
         // when
         List<MogakkoSimpleInfoResponseDto> filtered = mogakkoService.findAllByFilter(havingTagIds,
-            normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+            normalSearchVal, searchType, PAGE_SIZE, OFFSET);
         List<MogakkoSimpleInfoResponseDto> filteredWithoutTagIds = mogakkoService.findAllByFilter(Collections.emptyList(),
-            normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+            normalSearchVal, searchType, PAGE_SIZE, OFFSET);
         List<MogakkoSimpleInfoResponseDto> emptyFiltered = mogakkoService.findAllByFilter(Collections.emptyList(),
-            abnormalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+            abnormalSearchVal, searchType, PAGE_SIZE, OFFSET);
 
         // then
         assertThat(filtered).hasSize(2);
@@ -325,7 +322,7 @@ class MogakkoServiceTest {
         SearchType searchType = SearchType.TITLE_CONTENT;
 
         // when
-        List<MogakkoSimpleInfoResponseDto> allByFilter = mogakkoService.findAllByFilter(new ArrayList<>(), searchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+        List<MogakkoSimpleInfoResponseDto> allByFilter = mogakkoService.findAllByFilter(new ArrayList<>(), searchVal, searchType, PAGE_SIZE, OFFSET);
 
         // then
         assertThat(allByFilter).isNotEmpty();
@@ -368,7 +365,7 @@ class MogakkoServiceTest {
         // when, then
         assertThatThrownBy(
             () -> mogakkoService.findAllByFilter(null, search, SearchType.TITLE_CONTENT,
-                10, TEST_CURSOR_DTO))
+                10, OFFSET))
             .isInstanceOf(MogakkoException.class)
             .hasFieldOrPropertyWithValue("errorType", MogakkoErrorType.TOO_LITTLE_INPUT);
     }
@@ -434,20 +431,24 @@ class MogakkoServiceTest {
     @DisplayName("장소 기반 검색으로 모각코를 가져올 수 있다.")
     void success_find_all_by_filter_given_location() {
         // given
-        String normalSearchVal = "심곡본";
-        String abnormalSearchVal = "심본";
+        String normalCitySearchVal = "경기도 부천시 소사구 심곡본동";
+        String normalHCitySearchVal = "경기도 부천시 원미구 심곡1동";
+        String abnormalSearchVal = "심곡본동";
         SearchType searchType = SearchType.LOCATION;
         List<Long> havingTagIds = mogakkoTagRepository.findAllByMogakko(testMogakko).stream()
             .map(mt -> mt.getTag().getId()).toList();
 
         // when
-        List<MogakkoSimpleInfoResponseDto> normalResult = mogakkoService.findAllByFilter(
-            havingTagIds, normalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+        List<MogakkoSimpleInfoResponseDto> normalCityResult = mogakkoService.findAllByFilter(
+                havingTagIds, normalCitySearchVal, searchType, PAGE_SIZE, OFFSET);
+        List<MogakkoSimpleInfoResponseDto> normalHCityResult = mogakkoService.findAllByFilter(
+                new ArrayList<>(), normalHCitySearchVal, searchType, PAGE_SIZE, OFFSET);
         List<MogakkoSimpleInfoResponseDto> abnormalResult = mogakkoService.findAllByFilter(
-            havingTagIds, abnormalSearchVal, searchType, PAGE_SIZE, TEST_CURSOR_DTO);
+                havingTagIds, abnormalSearchVal, searchType, PAGE_SIZE, OFFSET);
 
         // then
-        assertThat(normalResult).hasSize(1);
+        assertThat(normalCityResult).hasSize(1);
+        assertThat(normalHCityResult).hasSize(1);
         assertThat(abnormalResult).isEmpty();
     }
 }

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/application/MogakkoServiceTest.java
@@ -29,7 +29,6 @@ import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocation;
 import org.prgms.locomocoserver.mogakkos.domain.location.MogakkoLocationRepository;
 import org.prgms.locomocoserver.mogakkos.domain.vo.AddressInfo;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
@@ -41,10 +41,7 @@ import org.springframework.util.MultiValueMap;
 
 @WebMvcTest(controllers = MogakkoController.class, excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { CorsFilter.class, AuthenticationFilter.class, ExceptionHandlerFilter.class, GlobalExceptionHandler.class }))
 class MogakkoControllerTest {
-    private static final long ID_CURSOR = Long.MAX_VALUE;
-    private static final long COUNT_CURSOR = Long.MAX_VALUE;
-    private static final LocalDateTime TIME_CURSOR = LocalDateTime.of(9990, 12, 31, 23, 59);
-    private static final CursorDto TEST_CURSOR_DTO = new CursorDto(ID_CURSOR, COUNT_CURSOR, TIME_CURSOR);
+    private static final long OFFSET = 0L;
     private static final int PAGE_SIZE = 20;
     private static final String API_VERSION = "/api/v1";
 
@@ -70,13 +67,11 @@ class MogakkoControllerTest {
             1200L, 22, LocalDateTime.now(), LocalDateTime.now(), 10, 4,
             new LocationInfoDto("주소2", 26.2642123d, 128.3622352d, "도시1", "행정동2"), List.copyOf(tags));
 
-        when(mogakkoService.findAllByFilter(tags, search, searchType, PAGE_SIZE, TEST_CURSOR_DTO))
+        when(mogakkoService.findAllByFilter(tags, search, searchType, PAGE_SIZE, OFFSET))
             .thenReturn(List.of(responseDto1, responseDto2));
 
         MultiValueMap<String, String> paramMap = new LinkedMultiValueMap<>();
-        paramMap.add("idCursor", String.valueOf(ID_CURSOR));
-        paramMap.add("timeCursor", String.valueOf(TIME_CURSOR));
-        paramMap.add("countCursor", String.valueOf(COUNT_CURSOR));
+        paramMap.add("offset", String.valueOf(OFFSET));
         paramMap.add("search", search);
         paramMap.add("searchType", searchType.name());
         paramMap.add("pageSize", String.valueOf(PAGE_SIZE));

--- a/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
+++ b/src/test/java/org/prgms/locomocoserver/mogakkos/presentation/MogakkoControllerTest.java
@@ -18,7 +18,6 @@ import org.prgms.locomocoserver.global.filter.ExceptionHandlerFilter;
 import org.prgms.locomocoserver.image.dto.ImageDto;
 import org.prgms.locomocoserver.mogakkos.application.MogakkoService;
 import org.prgms.locomocoserver.mogakkos.application.SearchType;
-import org.prgms.locomocoserver.mogakkos.dto.CursorDto;
 import org.prgms.locomocoserver.mogakkos.dto.LocationInfoDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoCreateRequestDto;
 import org.prgms.locomocoserver.mogakkos.dto.request.MogakkoUpdateRequestDto;


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [x] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #238 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* 모각코 검색을 오프셋 기반 검색으로 변경했습니다.
* 기존 풀텍스트 인덱스 검색을 이용했던 장소 검색을 LIKE % 검색으로 변경했습니다.

이전에 PR에서 말씀드렸듯 쿼리가 인덱스 풀 스캔을 하기 때문에 사실상 커서 기반 페이지네이션의 이점을 전혀 가져가지 못한다고 판단했습니다. 프론트에서도 커서를 3개나 넘겨주어야 했기 때문에 서로 번거로운 것으로 생각이 되었고 단순 오프셋 기반 페이지네이션으로 변경했습니다. 

풀텍스트 인덱스를 이용한 검색을 하면 관련도가 조금만 높아도 검색이 되어서 `경기도 부천시 소사구 심곡본동`을 검색했는데 `경기도 부천시 소사구 소사본동`도 같이 검색이 되는 일이 생겼습니다. 이에 따라 정확한 검색이 필요해졌으나 이러면 풀텍스트 인덱스의 강점이 사라지는 것 같았고, LIKE % 검색은 단순 인덱스도 타니까 `city`, `h_city`에 인덱스를 생성하고 이를 이용하는 게 더 낫지 않을까하는 생각이 들었습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
위에 대한 생각이 있으시면 말씀해 주세요~