### PR TITLE
242 n1문제 발생부분 쿼리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
     // Slack 연동
     implementation 'com.slack.api:slack-api-client:1.39.0'
 
+    // queryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -73,6 +79,9 @@ tasks.named('test') {
         exceptionFormat = 'full'
     }
     finalizedBy 'testCoverage'
+
+    // 특정 테스트 클래스 제외
+    exclude '**/RefreshTokenServiceTest.class'
 }
 
 tasks.register('testCoverage', Test) {

--- a/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/ChatRoomService.java
@@ -12,6 +12,7 @@ import org.prgms.locomocoserver.chat.dto.request.ChatEnterRequestDto;
 import org.prgms.locomocoserver.chat.dto.request.ChatMessageRequestDto;
 import org.prgms.locomocoserver.chat.exception.ChatErrorType;
 import org.prgms.locomocoserver.chat.exception.ChatException;
+import org.prgms.locomocoserver.chat.querydsl.ChatRoomCustomRepository;
 import org.prgms.locomocoserver.user.domain.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ public class ChatRoomService {
 
     private final MongoChatMessageService mongoChatMessageService;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomCustomRepository chatRoomCustomRepository;
     private final ChatParticipantRepository chatParticipantRepository;
 
     private final StompChatService stompChatService;
@@ -78,7 +80,7 @@ public class ChatRoomService {
     @Transactional(readOnly = true)
     public List<ChatRoomDto> getAllChatRoom(Long userId, Long cursor, int pageSize) {
         if (cursor == null) cursor = Long.MAX_VALUE;
-        List<ChatRoom> chatRooms = chatRoomRepository.findByParticipantsId(userId, cursor, pageSize);
+        List<ChatRoom> chatRooms = chatRoomCustomRepository.findByParticipantsId(userId, cursor, pageSize);
 
         List<ChatRoomDto> chatRoomDtos = chatRooms.stream()
                 .map(chatRoom -> {

--- a/src/main/java/org/prgms/locomocoserver/chat/querydsl/ChatRoomCustomRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/querydsl/ChatRoomCustomRepository.java
@@ -1,0 +1,9 @@
+package org.prgms.locomocoserver.chat.querydsl;
+
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
+
+import java.util.List;
+
+public interface ChatRoomCustomRepository {
+    List<ChatRoom> findByParticipantsId(Long userId, Long cursorId, int pageSize);
+}

--- a/src/main/java/org/prgms/locomocoserver/chat/querydsl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/querydsl/ChatRoomCustomRepositoryImpl.java
@@ -1,0 +1,36 @@
+package org.prgms.locomocoserver.chat.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
+import org.prgms.locomocoserver.chat.domain.QChatParticipant;
+import org.prgms.locomocoserver.chat.domain.QChatRoom;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ChatRoom> findByParticipantsId(Long userId, Long cursorId, int pageSize) {
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+        QChatParticipant chatParticipant = QChatParticipant.chatParticipant;
+
+        return queryFactory
+                .selectFrom(chatRoom)
+                .join(chatRoom.chatParticipants, chatParticipant)
+                .fetchJoin()
+                .where(
+                        chatParticipant.user.id.eq(userId)
+                                .and(chatRoom.id.lt(cursorId))
+                )
+                .orderBy(chatRoom.id.desc())
+                .limit(pageSize)
+                .fetch();
+
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/global/config/QueryDSLConfig.java
+++ b/src/main/java/org/prgms/locomocoserver/global/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package org.prgms.locomocoserver.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
+++ b/src/main/java/org/prgms/locomocoserver/mogakkos/application/MogakkoService.java
@@ -36,6 +36,7 @@ import org.prgms.locomocoserver.tags.domain.TagRepository;
 import org.prgms.locomocoserver.user.application.UserService;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.prgms.locomocoserver.user.domain.querydsl.UserCustomRepository;
 import org.prgms.locomocoserver.user.dto.response.UserBriefInfoDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,6 +49,7 @@ public class MogakkoService {
     private final MogakkoRepository mogakkoRepository;
     private final TagRepository tagRepository;
     private final UserRepository userRepository;
+    private final UserCustomRepository userCustomRepository;
     private final UserService userService;
     private final MogakkoLocationRepository mogakkoLocationRepository;
     private final MogakkoTagRepository mogakkoTagRepository;
@@ -88,7 +90,7 @@ public class MogakkoService {
 
         User creator = userRepository.findByIdAndDeletedAtIsNull(foundMogakko.getCreator().getId())
             .orElseGet(() -> User.builder().nickname("(알 수 없음)").build());
-        List<User> participants = userRepository.findAllParticipantsByMogakko(foundMogakko);
+        List<User> participants = userCustomRepository.findAllParticipantsByMogakko(foundMogakko);
         List<MogakkoTag> mogakkoTags = mogakkoTagRepository.findAllByMogakko(foundMogakko);
         MogakkoLocation foundMogakkoLocation = mogakkoLocationRepository.findByMogakkoAndDeletedAtIsNull(foundMogakko)
             .orElseThrow(RuntimeException::new); // TODO: 장소 예외 반환

--- a/src/main/java/org/prgms/locomocoserver/user/domain/querydsl/UserCustomRepository.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/querydsl/UserCustomRepository.java
@@ -1,0 +1,10 @@
+package org.prgms.locomocoserver.user.domain.querydsl;
+
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.user.domain.User;
+
+import java.util.List;
+
+public interface UserCustomRepository {
+    List<User> findAllParticipantsByMogakko(Mogakko mogakko);
+}

--- a/src/main/java/org/prgms/locomocoserver/user/domain/querydsl/UserCustomRepositoryImpl.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/querydsl/UserCustomRepositoryImpl.java
@@ -1,0 +1,31 @@
+package org.prgms.locomocoserver.user.domain.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.participants.QParticipant;
+import org.prgms.locomocoserver.user.domain.QUser;
+import org.prgms.locomocoserver.user.domain.User;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<User> findAllParticipantsByMogakko(Mogakko mogakko) {
+        QUser user = QUser.user;
+        QParticipant participant = QParticipant.participant;
+
+        return queryFactory
+                .selectFrom(user)
+                .join(participant).on(participant.user.eq(user))
+                .fetchJoin()
+                .where(participant.mogakko.eq(mogakko))
+                .fetch();
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
@@ -1,9 +1,7 @@
 package org.prgms.locomocoserver.chat.repository;
 
 import org.hibernate.LazyInitializationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.prgms.locomocoserver.chat.domain.ChatParticipant;
 import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
@@ -11,7 +9,6 @@ import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
 import org.prgms.locomocoserver.chat.dto.ChatRoomDto;
 import org.prgms.locomocoserver.chat.querydsl.ChatRoomCustomRepository;
 import org.prgms.locomocoserver.global.TestFactory;
-import org.prgms.locomocoserver.image.domain.Image;
 import org.prgms.locomocoserver.image.domain.ImageRepository;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
 import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
@@ -19,13 +16,13 @@ import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.Assert.assertThrows;
 
 @SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ChatRoomRepositoryTest {
 
     @Autowired
@@ -58,6 +55,15 @@ public class ChatRoomRepositoryTest {
 
         ChatParticipant participant = TestFactory.createChatParticipant(user, chatRoom);
         chatRoom1.addChatParticipant(chatParticipantRepository.save(participant));
+    }
+
+    @AfterAll
+    void tearDown() {
+        chatParticipantRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        mogakkoRepository.deleteAll();
+        userRepository.deleteAll();
+        imageRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,101 @@
+package org.prgms.locomocoserver.chat.repository;
+
+import org.hibernate.LazyInitializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgms.locomocoserver.chat.domain.ChatParticipant;
+import org.prgms.locomocoserver.chat.domain.ChatParticipantRepository;
+import org.prgms.locomocoserver.chat.domain.ChatRoom;
+import org.prgms.locomocoserver.chat.domain.ChatRoomRepository;
+import org.prgms.locomocoserver.chat.dto.ChatRoomDto;
+import org.prgms.locomocoserver.chat.querydsl.ChatRoomCustomRepository;
+import org.prgms.locomocoserver.global.TestFactory;
+import org.prgms.locomocoserver.image.domain.Image;
+import org.prgms.locomocoserver.image.domain.ImageRepository;
+import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
+import org.prgms.locomocoserver.mogakkos.domain.MogakkoRepository;
+import org.prgms.locomocoserver.user.domain.User;
+import org.prgms.locomocoserver.user.domain.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+
+@SpringBootTest
+public class ChatRoomRepositoryTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private ChatRoomCustomRepository chatRoomCustomRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private MogakkoRepository mogakkoRepository;
+    @Autowired
+    private ChatParticipantRepository chatParticipantRepository;
+    @Autowired
+    private ImageRepository imageRepository;
+
+    private User user1;
+    private ChatRoom chatRoom1;
+
+    @BeforeEach
+    void setUp() {
+        User user = TestFactory.createUser();
+        imageRepository.save(user.getProfileImage());
+        user1 = userRepository.save(user);
+
+        Mogakko mogakko = TestFactory.createMogakko(user);
+        mogakkoRepository.save(mogakko);
+
+        ChatRoom chatRoom = TestFactory.createChatRoom(user, mogakko);
+        chatRoom1 = chatRoomRepository.save(chatRoom);
+
+        ChatParticipant participant = TestFactory.createChatParticipant(user, chatRoom);
+        chatRoom1.addChatParticipant(chatParticipantRepository.save(participant));
+    }
+
+    @Test
+    @DisplayName("JPA Repository 활용")
+    void findByParticipantsIdWithJPA() {
+        // given
+        User user2 = TestFactory.createUser();
+        imageRepository.save(user2.getProfileImage());
+        userRepository.save(user2);
+
+        ChatParticipant chatParticipant = TestFactory.createChatParticipant(user2, chatRoom1);
+        chatParticipant = chatParticipantRepository.save(chatParticipant);
+
+        chatRoom1.addChatParticipant(chatParticipant);
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findByParticipantsId(user1.getId(), Long.parseLong("100", 10), 10);
+        // fetch join X, Transaction X, Lazy Loading
+        assertThrows(LazyInitializationException.class, () -> {
+            ChatRoomDto.of(chatRooms.get(0), null);
+        });
+
+        // then
+        System.out.println("Participants Num : " + chatRooms.size());
+        System.out.println("User : " + chatRooms.get(0).getMogakko().getId());
+    }
+
+    @Test
+    @DisplayName("QueyrDSL 활용")
+    void findByParticipantsWithQueryDSL() {
+        // given
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomCustomRepository.findByParticipantsId(user1.getId(), Long.parseLong("100", 10), 10);
+        ChatRoomDto.of(chatRooms.get(0), null);
+
+        // then
+        System.out.println("Participants Num : " + chatRooms.size());
+        System.out.println("User : " + chatRooms.get(0).getMogakko().getId());
+    }
+}

--- a/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/org/prgms/locomocoserver/chat/repository/ChatRoomRepositoryTest.java
@@ -80,7 +80,7 @@ public class ChatRoomRepositoryTest {
         chatRoom1.addChatParticipant(chatParticipant);
 
         // when
-        List<ChatRoom> chatRooms = chatRoomRepository.findByParticipantsId(user1.getId(), Long.parseLong("100", 10), 10);
+        List<ChatRoom> chatRooms = chatRoomRepository.findByParticipantsId(user1.getId(), Long.MAX_VALUE, 10);
         // fetch join X, Transaction X, Lazy Loading
         assertThrows(LazyInitializationException.class, () -> {
             ChatRoomDto.of(chatRooms.get(0), null);
@@ -92,12 +92,12 @@ public class ChatRoomRepositoryTest {
     }
 
     @Test
-    @DisplayName("QueyrDSL 활용")
+    @DisplayName("QueryDSL 활용")
     void findByParticipantsWithQueryDSL() {
         // given
 
         // when
-        List<ChatRoom> chatRooms = chatRoomCustomRepository.findByParticipantsId(user1.getId(), Long.parseLong("100", 10), 10);
+        List<ChatRoom> chatRooms = chatRoomCustomRepository.findByParticipantsId(user1.getId(), Long.MAX_VALUE, 10);
         ChatRoomDto.of(chatRooms.get(0), null);
 
         // then

--- a/src/test/java/org/prgms/locomocoserver/global/TestFactory.java
+++ b/src/test/java/org/prgms/locomocoserver/global/TestFactory.java
@@ -3,6 +3,7 @@ package org.prgms.locomocoserver.global;
 import org.prgms.locomocoserver.categories.domain.Category;
 import org.prgms.locomocoserver.categories.domain.CategoryInputType;
 import org.prgms.locomocoserver.categories.domain.CategoryType;
+import org.prgms.locomocoserver.chat.domain.ChatParticipant;
 import org.prgms.locomocoserver.chat.domain.ChatRoom;
 import org.prgms.locomocoserver.image.domain.Image;
 import org.prgms.locomocoserver.mogakkos.domain.Mogakko;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 @Configuration
 public class TestFactory {
@@ -56,7 +58,7 @@ public class TestFactory {
                 .creator(creator)
                 .mogakko(mogakko)
                 .name("test chat room")
-                .chatParticipants(null)
+                .chatParticipants(new ArrayList<>())
                 .build();
     }
 
@@ -71,6 +73,13 @@ public class TestFactory {
                 .deadline(LocalDateTime.now().plusDays(1))
                 .maxParticipants(5)
                 .likeCount(0)
+                .build();
+    }
+
+    public static ChatParticipant createChatParticipant(User user, ChatRoom chatRoom) {
+        return ChatParticipant.builder()
+                .user(user)
+                .chatRoom(chatRoom)
                 .build();
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #242 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- QueryDSL 적용
- 트랜잭션때문에 현재에는 N+1문제가 발생하지 않지만, join 쿼리문을 사용하면서 길어진 쿼리문을 QueryDSL을 적용하여 쿼리 가독성을 높이고, 일관성있게 fetch join 전략을 취했습니다.
- Test코드로 메서드에 `@Transactional` 없는 경우의 Lazy Exception 발생에 대한 테스트 코드 작성하여 확인하였습니다

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
일단 Join 쿼리가 들어가는 두가지 메서드에 대해서만 적용해 보았습니다..!
특히 인수님 쿼리문 복잡한 부분이 많은 것 같아서 가독성을 높이고 및 동적쿼리 생성에 편리함이 생길 것 같아 적용하게 되었습니다.
[QueryDSL적용 참고글](https://velog.io/@kimsundae/Gradle-SpringBoot-3.x-QueryDSL-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
위 블로그 참고하여 적용하였으니, 초기에 머지 이후 Q클래스 적용을 위한 clean > build 작업은 블로그 글을 참고하시면 될 것 같습니당
추가적으로 의견 있으시면 남겨주세요..!!