### PR TITLE
refactor 252 클라이언트의 잘못된 요청에 대해서는 슬랙 알림을 전송하지 않음.

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgms/locomocoserver/global/exception/GlobalExceptionHandler.java
@@ -9,9 +9,16 @@ import org.prgms.locomocoserver.image.exception.ImageException;
 import org.prgms.locomocoserver.mogakkos.exception.MogakkoException;
 import org.prgms.locomocoserver.review.exception.ReviewException;
 import org.prgms.locomocoserver.user.exception.UserException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -51,12 +58,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ex.getErrorType().getHttpStatus()).body(ex.getErrorType().getMessage());
     }
 
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class,
+        MissingServletRequestParameterException.class,
+        HttpMessageNotReadableException.class,
+        MethodArgumentNotValidException.class
+    })
+    public ResponseEntity<?> handleClientException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<?> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex) {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<?> handleMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex) {
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(ex.getMessage());
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleUnknownException(Exception ex, HttpServletRequest request) {
         slackAlertService.sendAlertLog(
             new SlackErrorAlertDto(request.getRequestURL().toString(), request.getMethod(),
                 ex.getMessage()));
         log.error("알 수 없는 에러 발생: {}", ex.getMessage(), ex);
-        return ResponseEntity.status(500).body(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ex.getMessage());
     }
 }


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #252 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
* 400, 405, 415 에러를 따로 받고 그대로 전송하도록 하였고, 이제 슬랙 알람을 발생시키지 않습니다.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
내용 그대로입니다! 다른 시나리오 있으면 말씀 주세요!