### PR TITLE
256 마이페이지 인증필터 재적용

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/global/config/AppConfig.java
+++ b/src/main/java/org/prgms/locomocoserver/global/config/AppConfig.java
@@ -25,7 +25,7 @@ public class AppConfig {
         FilterRegistrationBean<AuthenticationFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setOrder(3);
         registrationBean.setFilter(filter);
-        registrationBean.addUrlPatterns("/api/v1/chats/rooms/*"); // 필터를 적용할 URL 패턴 지정
+        registrationBean.addUrlPatterns("/api/v1/chats/rooms/*", "/api/v1/users/*"); // 필터를 적용할 URL 패턴 지정
 
         return registrationBean;
     }

--- a/src/main/java/org/prgms/locomocoserver/global/filter/AuthenticationFilter.java
+++ b/src/main/java/org/prgms/locomocoserver/global/filter/AuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.prgms.locomocoserver.global.exception.ErrorCode;
 import org.prgms.locomocoserver.user.application.AuthenticationService;
 import org.prgms.locomocoserver.user.application.RefreshTokenService;
 import org.prgms.locomocoserver.user.application.TokenService;
+import org.prgms.locomocoserver.user.domain.RefreshToken;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.enums.Provider;
 import org.prgms.locomocoserver.user.dto.response.TokenResponseDto;
@@ -111,25 +112,10 @@ public class AuthenticationFilter implements Filter {
             User user = tokenService.getUserFromToken(accessToken.substring(7), providerValue);
             UserContext.setUser(user);
             log.info("User Context: {}", user.getEmail());
-        } else if (Provider.KAKAO.name().equals(providerValue)) {
-            processTokenRefresh(response, accessToken);
         } else {
             log.error("Authentication failed (AuthFilter): {}", ErrorCode.INVALID_TOKEN.getMessage());
             throw new AuthException(ErrorCode.INVALID_TOKEN);
         }
-    }
-
-    private void processTokenRefresh(HttpServletResponse response, String accessToken) throws IOException {
-        log.info("Refreshing access token");
-
-        TokenResponseDto tokenResponseDto = refreshTokenService.updateAccessToken(accessToken);
-        String jsonResponse = objectMapper.writeValueAsString(tokenResponseDto);
-
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.setContentType("application/json");
-        response.getWriter().write(jsonResponse);
-
-        log.info("New access token issued: {}", tokenResponseDto.accessToken());
     }
 
     private boolean isPatternMatch(String pattern, String method, String url) {

--- a/src/main/java/org/prgms/locomocoserver/global/property/AuthProperties.java
+++ b/src/main/java/org/prgms/locomocoserver/global/property/AuthProperties.java
@@ -1,0 +1,16 @@
+package org.prgms.locomocoserver.global.property;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Component
+public class AuthProperties {
+    private final List<String> authRequired = List.of(
+            "GET:/api/v1/chats/rooms/\\d+",
+            "PATCH:/api/v1/mogakko/map/\\d+",
+            "GET:/api/v1/users/\\d+"
+    );
+}

--- a/src/main/java/org/prgms/locomocoserver/global/property/CorsProperties.java
+++ b/src/main/java/org/prgms/locomocoserver/global/property/CorsProperties.java
@@ -1,0 +1,19 @@
+package org.prgms.locomocoserver.global.property;
+
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+@Getter
+@Component
+public class CorsProperties {
+    private final Set<String> allowedOrigins = new HashSet<>(Arrays.asList(
+            "http://localhost:3000",
+            "https://locomoco.kro.kr",
+            "https://locomoco.shop",
+            "http://localhost:8090"
+    ));
+}

--- a/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/RefreshTokenService.java
@@ -44,11 +44,6 @@ public class RefreshTokenService {
         return tokenResponseDto;
     }
 
-    public RefreshToken getByAccessToken(String accessToken) {
-        return refreshTokenRepository.findByAccessToken(accessToken)
-                .orElseThrow(() -> new AuthException(ErrorCode.NO_ACCESS_TOKEN));
-    }
-
     private RefreshToken getByRefreshToken(String refreshToken) {
         return refreshTokenRepository.findById(refreshToken)
                 .orElseThrow(() -> new AuthException(ErrorCode.ACCESSTOKEN_EXPIRED));

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
@@ -7,20 +7,20 @@ import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
-@RedisHash(value = "refresh_token", timeToLive = 60*60*24*3)
+@RedisHash(value = "refresh_token", timeToLive = RefreshToken.TOKEN_TTL)
 public class RefreshToken {
 
+    public static final long TOKEN_TTL = 60 * 60 * 24 * 3; // 3일
+
     @Id
-    private String id;
+    private String refreshToken;
 
     @Indexed
     private String accessToken;
 
-    private String refreshToken;
-
     @Builder
-    public RefreshToken(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
+    public RefreshToken(String refreshToken, String accessToken) {
         this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
+++ b/src/main/java/org/prgms/locomocoserver/user/domain/RefreshToken.java
@@ -1,8 +1,8 @@
 package org.prgms.locomocoserver.user.domain;
 
-import jakarta.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/KakaoController.java
@@ -70,8 +70,8 @@ public class KakaoController {
 
     @Operation(summary = "accessToken 재발급", description = "accessToken이 만료되어 재발급합니다.")
     @GetMapping("/users/refresh/kakao")
-    public ResponseEntity<TokenResponseDto> refreshToken(@RequestHeader String accessToken) {
-        TokenResponseDto tokenResponseDto = refreshTokenService.updateAccessToken(accessToken);
+    public ResponseEntity<TokenResponseDto> refreshToken(@RequestHeader String refreshToken) {
+        TokenResponseDto tokenResponseDto = refreshTokenService.updateAccessToken(refreshToken);
         return ResponseEntity.ok(tokenResponseDto);
     }
 

--- a/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
+++ b/src/main/java/org/prgms/locomocoserver/user/presentation/UserController.java
@@ -57,8 +57,8 @@ public class UserController {
 
     @Operation(summary = "마이페이지 정보", description = "사용자 마이페이지 정보를 반환합니다.")
     @GetMapping("/users/{userId}")
-    public ResponseEntity<UserMyPageDto> getUserInfo(@PathVariable Long userId) {
-//        log.info("getUserInfo : {}", user.getEmail());
+    public ResponseEntity<UserMyPageDto> getUserInfo(@PathVariable Long userId, @GetUser User user) {
+        log.info("User Controller - 인증 성공 getUserInfo : {}", user.getEmail());
         UserMyPageDto myPageDto = userService.getUserInfo(userId);
 
         return ResponseEntity.ok(myPageDto);

--- a/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
+++ b/src/test/java/org/prgms/locomocoserver/user/application/RefreshTokenServiceTest.java
@@ -55,7 +55,7 @@ class RefreshTokenServiceTest extends AbstractRedisContainerBaseTest {
         String accessToken = refreshTokenService.saveTokenInfo(tokenResponseDto);
 
         // when
-        refreshTokenService.removeAccessToken(accessToken);
+        refreshTokenService.removeRefreshToken(tokenResponseDto.refreshToken());
 
         // then
         assertEquals(0, refreshTokenRepository.count());


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #256 : 기존에 RefreshToken의 활용을 제대로 하지 못하고 있었는데, Redis 엔터티 개념 다시 학습후에 id값을 refreshToken으로 수정하였습니다

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
- RefreshToken 엔터티 구조 변경 (id만 삭제, 기존 refreshToken을 id로 지정)
- accessToken으로 자동 토큰 재발급 방식 삭제 후 프론트에서 api를 통한 재발급하도록 변경
- cors,auth 적용 프로퍼티 리스트 따로 분리
- user api 인증필터 적용

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
redis 테스트가 불가하고 커스텀 어노테이션 적용이 필터단에서 이루어져서 빠르게 머지하고 확인해야 할 것 같습니다..!
