### PR TITLE
262 stomp 세션 관리 로직 추가

### DIFF
--- a/src/main/java/org/prgms/locomocoserver/chat/application/StompChatService.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/StompChatService.java
@@ -11,10 +11,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StompChatService {
 
+    static final String DESTINATION_ROUTE = "/sub/chat/room/";
+
     private final SimpMessagingTemplate template;
 
     public void sendToSubscribers(ChatMessageDto chatMessageDto) {
         log.info("sendToSubscribers: " + chatMessageDto.message() + " " + chatMessageDto.senderNickName());
-        template.convertAndSend("/sub/chat/room/" + chatMessageDto.chatRoomId(), chatMessageDto);
+        template.convertAndSend(DESTINATION_ROUTE + chatMessageDto.chatRoomId(), chatMessageDto);
     }
 }

--- a/src/main/java/org/prgms/locomocoserver/chat/application/StompEventListener.java
+++ b/src/main/java/org/prgms/locomocoserver/chat/application/StompEventListener.java
@@ -1,0 +1,59 @@
+package org.prgms.locomocoserver.chat.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.chat.dto.ChatMessageDto;
+import org.prgms.locomocoserver.chat.dto.request.ChatActivityRequestDto;
+import org.prgms.locomocoserver.chat.exception.ChatErrorType;
+import org.prgms.locomocoserver.chat.exception.ChatException;
+import org.prgms.locomocoserver.user.domain.User;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectedEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import static org.prgms.locomocoserver.chat.application.StompChatService.DESTINATION_ROUTE;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompEventListener {
+
+    private final ChatActivityService chatActivityService;
+    private final ChatMessagePolicy chatMessagePolicy;
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectedEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        // 세션에서 user 속성 가져오기
+        User user = (User) headerAccessor.getSessionAttributes().get("user");
+        String sessionId = headerAccessor.getSessionId();
+
+        if (user != null) {
+            log.info("Client connected: " + sessionId + " (User: " + user.getNickname() + ")");
+        } else {
+            log.error("Client connected: " + sessionId + " (User: Unknown)");
+            throw new ChatException(ChatErrorType.CHAT_PARTICIPANT_NOT_FOUND, "Client connected: " + sessionId);
+        }
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        // 세션에서 user 속성 가져오기
+        User user = (User) headerAccessor.getSessionAttributes().get("user");
+        String sessionId = headerAccessor.getSessionId();
+        Long chatRoomId = Long.parseLong(headerAccessor.getDestination().substring(DESTINATION_ROUTE.length()));
+
+        if (user!= null) {
+            log.info("Client disconnected: " + sessionId + " (User: " + user.getNickname() + ")");
+
+            ChatMessageDto chatMessageDto = chatMessagePolicy.getLastChatMessage(chatRoomId);
+            chatActivityService.updateLastReadMessage(chatRoomId, new ChatActivityRequestDto(user.getId(), chatMessageDto.chatMessageId()));
+        } else {
+            log.error("Client disconnected: " + sessionId + " (User: Unknown)");
+        }
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/global/config/WebSocketConfig.java
+++ b/src/main/java/org/prgms/locomocoserver/global/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package org.prgms.locomocoserver.global.config;
 
+import lombok.RequiredArgsConstructor;
+import org.prgms.locomocoserver.global.interceptor.CustomHandshakeInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -7,13 +9,17 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final CustomHandshakeInterceptor customHandshakeInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
 
         registry.addEndpoint("/api/v1/stomp/chat")
+                .addInterceptors(customHandshakeInterceptor)
                 .setAllowedOrigins("http://localhost:8090", "http://localhost:3000", "https://locomoco.kro.kr")
                 .withSockJS(); // 웹소켓 핸드셰이크 커넥션 생성 경로
     }

--- a/src/main/java/org/prgms/locomocoserver/global/interceptor/CustomHandshakeInterceptor.java
+++ b/src/main/java/org/prgms/locomocoserver/global/interceptor/CustomHandshakeInterceptor.java
@@ -1,0 +1,44 @@
+package org.prgms.locomocoserver.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.user.application.TokenService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final TokenService tokenService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        String accessToken = httpServletRequest.getHeader("Authorization");
+        String provider = httpServletRequest.getHeader("provider");
+
+        boolean isValidToken = tokenService.isValidToken(accessToken, provider);
+        if (isValidToken) {
+            attributes.put("user", tokenService.getUserFromToken(accessToken.substring(7), provider));
+            return true;
+        } else {
+            response.setStatusCode(HttpStatus.UNAUTHORIZED); // 인증 실패
+            return false;
+        }
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/org/prgms/locomocoserver/user/application/TokenService.java
+++ b/src/main/java/org/prgms/locomocoserver/user/application/TokenService.java
@@ -3,6 +3,8 @@ package org.prgms.locomocoserver.user.application;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.prgms.locomocoserver.global.exception.AuthException;
+import org.prgms.locomocoserver.global.exception.ErrorCode;
 import org.prgms.locomocoserver.user.domain.User;
 import org.prgms.locomocoserver.user.domain.UserRepository;
 import org.prgms.locomocoserver.user.dto.OAuthUserInfoDto;
@@ -20,6 +22,16 @@ public class TokenService {
     private final KakaoController kakaoController;
     private final GithubController githubController;
     private final UserRepository userRepository;
+    private final AuthenticationService authenticationService;
+
+    public boolean isValidToken(String accessToken, String provider) {
+        if (accessToken == null || provider == null) {
+            log.error("Authentication failed: {}", ErrorCode.NO_ACCESS_TOKEN.getMessage());
+            throw new AuthException(ErrorCode.NO_ACCESS_TOKEN);
+        }
+
+        return authenticationService.authenticateUser(provider, accessToken);
+    }
 
     public User getUserFromToken(String token, String providerValue) throws JsonProcessingException {
         OAuthUserInfoDto userInfoDto;


### PR DESCRIPTION
<!-- PR 작성 전에 우선 Reviewers, Assignees, label 지정하기 -->
## 🧙 PR 타입
<!-- 하나 이상의 PR 타입을 선택 -->
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🤨 Motivation
<!-- 코드를 추가/변경하게 된 이유 및 해결한 이슈 번호 
ex) - Resolved #2 -->
Resolved #262 

## 🔑 Key Changes
<!-- 주요 구현 사항 -->
1. `HandShakeInterceptor` 구현
  - TLS handshake 진행 전에 사용자 인증 및 인가를 처리.
  - WebSocket attributes에 user 데이터를 저장하여 세션에서 사용자 정보를 관리 가능.
  
2. `EventListener` 구현
  - WebSocket Connect 이벤트: 연결 시 인증 및 인가가 완료된 사용자 여부를 확인.
  - WebSocket Disconnect 이벤트: 연결 해제 시, 사용자 세션 정보를 활용하여 lastReadMsgId 값을 자동 업데이트.

## 🙏 To Reviewers
<!-- 리뷰어에게 전달할 말 -->
기존에는 프론트엔드에서 API 호출을 통해 lastReadMsgId 값을 업데이트하려 했으나, 이 방법이 비효율적이라는 판단이 들어서 방법을 찾아보았습니다.
서버에서 WebSocket 세션 접근을 활용하여 lastReadMsgId를 업데이트하는 방법을 알게되어 구현하였습니다.

현재 접근 방식에 대해 개선할 점이 있다면 코멘트 부탁드립니다!